### PR TITLE
Fix bug for wrongly-displayed app states

### DIFF
--- a/CloudFoundryApiClient.UnitTests/CfApiClientTests.cs
+++ b/CloudFoundryApiClient.UnitTests/CfApiClientTests.cs
@@ -364,7 +364,7 @@ namespace Tanzu.Toolkit.CloudFoundryApiClient.Tests
             Exception resultException = null;
 
             MockedRequest cfStopAppRequest = _mockHttp.Expect(expectedPath)
-               .Respond("application/json", JsonConvert.SerializeObject(new App { state = "STOPPED" }));
+               .Respond("application/json", JsonConvert.SerializeObject(new App { State = "STOPPED" }));
 
             _sut = new CfApiClient(_mockUaaClient.Object, _mockHttp.ToHttpClient());
 
@@ -391,7 +391,7 @@ namespace Tanzu.Toolkit.CloudFoundryApiClient.Tests
             Exception resultException = null;
 
             MockedRequest cfStopAppRequest = _mockHttp.Expect(expectedPath)
-               .Respond("application/json", JsonConvert.SerializeObject(new App { state = "fake state != STOPPED" }));
+               .Respond("application/json", JsonConvert.SerializeObject(new App { State = "fake state != STOPPED" }));
 
             _sut = new CfApiClient(_mockUaaClient.Object, _mockHttp.ToHttpClient());
 
@@ -418,7 +418,7 @@ namespace Tanzu.Toolkit.CloudFoundryApiClient.Tests
             Exception resultException = null;
 
             MockedRequest cfStartAppRequest = _mockHttp.Expect(expectedPath)
-               .Respond("application/json", JsonConvert.SerializeObject(new App { state = "STARTED" }));
+               .Respond("application/json", JsonConvert.SerializeObject(new App { State = "STARTED" }));
 
             _sut = new CfApiClient(_mockUaaClient.Object, _mockHttp.ToHttpClient());
 
@@ -445,7 +445,7 @@ namespace Tanzu.Toolkit.CloudFoundryApiClient.Tests
             Exception resultException = null;
 
             MockedRequest cfStartAppRequest = _mockHttp.Expect(expectedPath)
-               .Respond("application/json", JsonConvert.SerializeObject(new App { state = "fake state != STARTED" }));
+               .Respond("application/json", JsonConvert.SerializeObject(new App { State = "fake state != STARTED" }));
 
             _sut = new CfApiClient(_mockUaaClient.Object, _mockHttp.ToHttpClient());
 

--- a/CloudFoundryApiClient/CfApiClient.cs
+++ b/CloudFoundryApiClient/CfApiClient.cs
@@ -228,7 +228,7 @@ namespace Tanzu.Toolkit.CloudFoundryApiClient
             string resultContent = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<App>(resultContent);
 
-            if (result.state == "STOPPED") return true;
+            if (result.State == "STOPPED") return true;
             return false;
         }
 
@@ -271,7 +271,7 @@ namespace Tanzu.Toolkit.CloudFoundryApiClient
             string resultContent = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<App>(resultContent);
 
-            if (result.state == "STARTED") return true;
+            if (result.State == "STARTED") return true;
             return false;
         }
 

--- a/CloudFoundryApiClient/Models/AppsResponse.cs
+++ b/CloudFoundryApiClient/Models/AppsResponse.cs
@@ -19,7 +19,8 @@ namespace Tanzu.Toolkit.CloudFoundryApiClient.Models.AppsResponse
         public string Guid { get; set; }
         [JsonProperty("name")]
         public string Name { get; set; }
-        public string state { get; set; }
+        [JsonProperty("state")]
+        public string State { get; set; }
         public DateTime created_at { get; set; }
         public DateTime updated_at { get; set; }
         public Lifecycle lifecycle { get; set; }

--- a/Models/CloudFoundryApp.cs
+++ b/Models/CloudFoundryApp.cs
@@ -7,11 +7,12 @@
         public CloudFoundrySpace ParentSpace { get; set; }
         public string State { get; set; }
 
-        public CloudFoundryApp(string appName, string appGuid, CloudFoundrySpace parentSpace)
+        public CloudFoundryApp(string appName, string appGuid, CloudFoundrySpace parentSpace, string state)
         {
             AppName = appName;
             AppId = appGuid;
             ParentSpace = parentSpace;
+            State = state;
         }
 
     }

--- a/Services.Tests/CloudFoundry/CloudFoundryServiceTests.cs
+++ b/Services.Tests/CloudFoundry/CloudFoundryServiceTests.cs
@@ -25,7 +25,7 @@ namespace Tanzu.Toolkit.VisualStudio.Services.Tests.CloudFoundry
             fakeCfInstance = new CloudFoundryInstance("fake cf", fakeValidTarget, fakeValidAccessToken);
             fakeOrg = new CloudFoundryOrganization("fake org", "fake org guid", fakeCfInstance);
             fakeSpace = new CloudFoundrySpace("fake space", "fake space guid", fakeOrg);
-            fakeApp = new CloudFoundryApp("fake app", "fake app guid", fakeSpace);
+            fakeApp = new CloudFoundryApp("fake app", "fake app guid", fakeSpace, null);
         }
 
         [TestCleanup]
@@ -472,30 +472,34 @@ namespace Tanzu.Toolkit.VisualStudio.Services.Tests.CloudFoundry
                 {
                     Name = app1Name,
                     Guid = app1Guid,
+                    State = app1State,
                 },
                 new CloudFoundryApiClient.Models.AppsResponse.App
                 {
                     Name = app2Name,
                     Guid = app2Guid,
+                    State = app2State,
                 },
                 new CloudFoundryApiClient.Models.AppsResponse.App
                 {
                     Name = app3Name,
                     Guid = app3Guid,
+                    State = app3State,
                 },
                 new CloudFoundryApiClient.Models.AppsResponse.App
                 {
                     Name = app4Name,
                     Guid = app4Guid,
+                    State = app4State,
                 },
             };
 
             var expectedResultContent = new List<CloudFoundryApp>
             {
-                new CloudFoundryApp(app1Name, app1Guid, fakeSpace),
-                new CloudFoundryApp(app2Name, app2Guid, fakeSpace),
-                new CloudFoundryApp(app3Name, app3Guid, fakeSpace),
-                new CloudFoundryApp(app4Name, app4Guid, fakeSpace)
+                new CloudFoundryApp(app1Name, app1Guid, fakeSpace, app1State),
+                new CloudFoundryApp(app2Name, app2Guid, fakeSpace, app2State),
+                new CloudFoundryApp(app3Name, app3Guid, fakeSpace, app3State),
+                new CloudFoundryApp(app4Name, app4Guid, fakeSpace, app4State)
             };
             
             mockCfCliService.Setup(m => m.

--- a/Services.Tests/ServicesTestSupport.cs
+++ b/Services.Tests/ServicesTestSupport.cs
@@ -80,6 +80,10 @@ namespace Tanzu.Toolkit.VisualStudio.Services.Tests
         internal static readonly string app2Guid = "app-2-id";
         internal static readonly string app3Guid = "app-3-id";
         internal static readonly string app4Guid = "app-4-id";
+        internal static readonly string app1State = "STARTED";
+        internal static readonly string app2State = "STOPPED";
+        internal static readonly string app3State = "STARTED";
+        internal static readonly string app4State = "STOPPED";
 
         internal static readonly List<Org> mockOrgsResponse = new List<Org>
         {

--- a/Services/CloudFoundry/CloudFoundryService.cs
+++ b/Services/CloudFoundry/CloudFoundryService.cs
@@ -296,7 +296,7 @@ namespace Tanzu.Toolkit.VisualStudio.Services.CloudFoundry
                 }
                 else
                 {
-                    appsToReturn.Add(new CloudFoundryApp(app.Name, app.Guid, space));
+                    appsToReturn.Add(new CloudFoundryApp(app.Name, app.Guid, space, app.State.ToUpper()));
                 }
             }
 

--- a/ViewModel.Tests/AppViewModel.cs
+++ b/ViewModel.Tests/AppViewModel.cs
@@ -13,7 +13,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         public void Constructor_SetsDisplayTextToAppName()
         {
             string appName = "junk";
-            var fakeApp = new CloudFoundryApp(appName, null, null);
+            var fakeApp = new CloudFoundryApp(appName, null, null, null);
 
             avm = new AppViewModel(fakeApp, services);
 
@@ -23,7 +23,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public void IsStopped_ReturnsTrue_WhenAppStateIsSTOPPED()
         {
-            var fakeApp = new CloudFoundryApp("fake name", "fake guid", null)
+            var fakeApp = new CloudFoundryApp("fake name", "fake guid", null, null)
             {
                 State = "STOPPED"
             };
@@ -36,7 +36,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public void IsStopped_ReturnsFalse_WhenAppStateIsNotSTOPPED()
         {
-            var fakeApp = new CloudFoundryApp("fake name", "fake guid", null)
+            var fakeApp = new CloudFoundryApp("fake name", "fake guid", null, null)
             {
                 State = "anything-other-than-STOPPED"
             };

--- a/ViewModel.Tests/CloudExplorerViewModelTests.cs
+++ b/ViewModel.Tests/CloudExplorerViewModelTests.cs
@@ -118,7 +118,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public async Task StopCfApp_CallsStopCfAppAsync()
         {
-            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null);
+            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             mockCloudFoundryService.Setup(mock => mock.StopAppAsync(fakeApp, true)).ReturnsAsync(fakeSuccessDetailedResult);
 
@@ -139,7 +139,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public async Task StopCfApp_DisplaysErrorDialog_WhenStopAppAsyncFails()
         {
-            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null);
+            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             mockCloudFoundryService.Setup(mock => mock.
                 StopAppAsync(fakeApp, true))
@@ -158,7 +158,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public async Task StopCfApp_LogsError_WhenStopAppAsyncFails()
         {
-            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null);
+            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             mockCloudFoundryService.Setup(mock => mock.
                 StopAppAsync(fakeApp, true))
@@ -178,7 +178,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public async Task StartCfApp_CallsStartAppAsync()
         {
-            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null);
+            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             mockCloudFoundryService.Setup(mock => mock.StartAppAsync(fakeApp, true)).ReturnsAsync(fakeSuccessDetailedResult);
 
@@ -199,7 +199,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public async Task StartCfApp_DisplaysErrorDialog_WhenStartAppAsyncFails()
         {
-            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null);
+            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             mockCloudFoundryService.Setup(mock => mock.
                 StartAppAsync(fakeApp, true))
@@ -218,7 +218,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public async Task StartCfApp_LogsError_WhenStartAppAsyncFails()
         {
-            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null);
+            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             mockCloudFoundryService.Setup(mock => mock.
                 StartAppAsync(fakeApp, true))
@@ -238,7 +238,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public async Task DeleteCfApp_CallsDeleteAppAsync()
         {
-            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null);
+            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             mockCloudFoundryService.Setup(mock => mock.DeleteAppAsync(fakeApp, true, true)).ReturnsAsync(fakeSuccessDetailedResult);
 
@@ -259,7 +259,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public async Task DeleteCfApp_DisplaysErrorDialog_WhenDeleteAppAsyncFails()
         {
-            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null);
+            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             mockCloudFoundryService.Setup(mock => mock.
                 DeleteAppAsync(fakeApp, true, true))
@@ -279,7 +279,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public async Task DeleteCfApp_LogsError_WhenDeleteAppAsyncFails()
         {
-            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null);
+            var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             mockCloudFoundryService.Setup(mock => mock.
                 DeleteAppAsync(fakeApp, true, true))
@@ -299,7 +299,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public void RefreshApp_RaisesPropertyChangedEventForIsStopped()
         {
-            CloudFoundryApp fakeApp = new CloudFoundryApp("fake app name", "fake app guid", null);
+            CloudFoundryApp fakeApp = new CloudFoundryApp("fake app name", "fake app guid", null, null);
             var avm = new AppViewModel(fakeApp, services);
 
             avm.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
@@ -578,7 +578,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
 
             fakeSpaceViewModel.Children = new ObservableCollection<TreeViewItemViewModel>
             {
-                new AppViewModel(new CloudFoundryApp(fakeAppName1, fakeAppGuid1, fakeSpace), services)
+                new AppViewModel(new CloudFoundryApp(fakeAppName1, fakeAppGuid1, fakeSpace, null), services)
             };
 
             fakeSpaceViewModel.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
@@ -592,8 +592,8 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
 
             var fakeAppsResponseContent = new List<CloudFoundryApp>
             {
-                new CloudFoundryApp(fakeAppName2, fakeAppGuid2, fakeSpace),
-                new CloudFoundryApp(fakeAppName3, fakeAppGuid3, fakeSpace)
+                new CloudFoundryApp(fakeAppName2, fakeAppGuid2, fakeSpace, null),
+                new CloudFoundryApp(fakeAppName3, fakeAppGuid3, fakeSpace, null)
             };
             var fakeAppsResult = new DetailedResult<List<CloudFoundryApp>>(
                 succeeded: true,
@@ -630,7 +630,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
 
             fakeSpaceViewModel.Children = new ObservableCollection<TreeViewItemViewModel>
             {
-                new AppViewModel(new CloudFoundryApp(fakeAppName1, fakeAppGuid1, fakeSpace), services)
+                new AppViewModel(new CloudFoundryApp(fakeAppName1, fakeAppGuid1, fakeSpace, null), services)
             };
 
             var newEmptyAppsList = new List<CloudFoundryApp>();
@@ -669,7 +669,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
 
             var newAppsList = new List<CloudFoundryApp>
             {
-                new CloudFoundryApp(fakeAppName1, fakeAppGuid1, fakeSpace),
+                new CloudFoundryApp(fakeAppName1, fakeAppGuid1, fakeSpace, null),
             };
 
             var fakeSuccessResult = new DetailedResult<List<CloudFoundryApp>>(succeeded: true, content: newAppsList);
@@ -703,8 +703,8 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
             var fakeNewSpace = new CloudFoundrySpace("new space", "new space id", fakeInitialOrg);
             var svm = new SpaceViewModel(fakeInitialSpace, services);
 
-            var fakeInitialApp = new CloudFoundryApp("fake app name", "fake app id", fakeInitialSpace);
-            var fakeNewApp = new CloudFoundryApp("new app", "new app id", fakeInitialSpace);
+            var fakeInitialApp = new CloudFoundryApp("fake app name", "fake app id", fakeInitialSpace, null);
+            var fakeNewApp = new CloudFoundryApp("new app", "new app id", fakeInitialSpace, null);
             var avm = new AppViewModel(fakeInitialApp, services);
 
             var fakeCfDict = new Dictionary<string, CloudFoundryInstance>
@@ -948,7 +948,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
             var fakeInitialSpace = new CloudFoundrySpace("fake space name", "fake space id", fakeInitialOrg);
             var svm = new SpaceViewModel(fakeInitialSpace, services);
 
-            var fakeInitialApp = new CloudFoundryApp("fake app name", "fake app id", fakeInitialSpace);
+            var fakeInitialApp = new CloudFoundryApp("fake app name", "fake app id", fakeInitialSpace, null);
             var avm = new AppViewModel(fakeInitialApp, services);
 
             var fakeCfDict = new Dictionary<string, CloudFoundryInstance>
@@ -1156,7 +1156,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
             svm.Children = new ObservableCollection<TreeViewItemViewModel> { svm.EmptyPlaceholder };
             svm.HasEmptyPlaceholder = true;
 
-            var fakeNewApp = new CloudFoundryApp("fake app name", "fake app id", fakeInitialSpace);
+            var fakeNewApp = new CloudFoundryApp("fake app name", "fake app id", fakeInitialSpace, null);
             var avm = new AppViewModel(fakeNewApp, services);
 
             var fakeCfDict = new Dictionary<string, CloudFoundryInstance>

--- a/ViewModel.Tests/SpaceViewModelTests.cs
+++ b/ViewModel.Tests/SpaceViewModelTests.cs
@@ -55,15 +55,15 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         {
             var initialAppsList = new System.Collections.ObjectModel.ObservableCollection<TreeViewItemViewModel>
             {
-                new AppViewModel(new CloudFoundryApp("initial app 1", null, null), services),
-                new AppViewModel(new CloudFoundryApp("initial app 2", null, null), services),
-                new AppViewModel(new CloudFoundryApp("initial app 3", null, null), services),
+                new AppViewModel(new CloudFoundryApp("initial app 1", null, null, null), services),
+                new AppViewModel(new CloudFoundryApp("initial app 2", null, null, null), services),
+                new AppViewModel(new CloudFoundryApp("initial app 3", null, null, null), services),
             };
 
             var newAppsList = new List<CloudFoundryApp>
             {
-                new CloudFoundryApp("initial app 1", null, null),
-                new CloudFoundryApp("initial app 2", null, null)
+                new CloudFoundryApp("initial app 1", null, null, null),
+                new CloudFoundryApp("initial app 2", null, null, null)
             };
             var fakeAppsResult = new DetailedResult<List<CloudFoundryApp>>(
                 succeeded: true,
@@ -143,8 +143,8 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         {
             var fakeAppsList = new List<CloudFoundryApp>
             {
-                new CloudFoundryApp("fake app name 1","fake app id 1", fakeCfSpace),
-                new CloudFoundryApp("fake app name 2","fake app id 2", fakeCfSpace)
+                new CloudFoundryApp("fake app name 1","fake app id 1", fakeCfSpace, null),
+                new CloudFoundryApp("fake app name 2","fake app id 2", fakeCfSpace, null),
             };
 
             var fakeAppsResult = new DetailedResult<List<CloudFoundryApp>>(


### PR DESCRIPTION
- CloudFoundryService wasn't specifying an initial state for apps, so
  they were defaulting to "STARTED".
- Made state a required ctor param for CloudFoundryApp to prevent
  stateless apps in the future.