### PR TITLE
Deploy full-framework apps from the VS Solution Explorer

### DIFF
--- a/Services.Tests/CfCli/CfCliServiceTests.cs
+++ b/Services.Tests/CfCli/CfCliServiceTests.cs
@@ -1028,8 +1028,65 @@ namespace Tanzu.Toolkit.VisualStudio.Services.Tests.CfCli
             Assert.IsNull(result.Explanation);
             Assert.AreEqual(fakeSuccessCmdResult, result.CmdDetails);
         }
-
+        
         [TestMethod]
+        [TestCategory("PushApp")]
+        public async Task PushAppAsync_AddsSFlag_WhenGivenAStackParam()
+        {
+            var fakeAppName = "my fake app";
+            var fakeStackValue = "my-cool-stack-name";
+            string expectedArgs = $"push \"{fakeAppName}\" -s {fakeStackValue}"; // ensure app name gets surrounded by quotes
+
+            mockCmdProcessService.Setup(m => m.
+                RunCommand(_fakePathToCfExe, expectedArgs, fakeProjectPath, null, null))
+                    .Returns(fakeSuccessCmdResult);
+
+            var result = await _sut.PushAppAsync(fakeAppName, null, null, fakeProjectPath, stack: fakeStackValue);
+
+            Assert.IsTrue(result.Succeeded);
+            Assert.IsNull(result.Explanation);
+            Assert.AreEqual(fakeSuccessCmdResult, result.CmdDetails);
+        }
+        
+        [TestMethod]
+        [TestCategory("PushApp")]
+        public async Task PushAppAsync_AddsBFlag_WhenGivenABuildpackParam()
+        {
+            var fakeAppName = "my fake app";
+            var fakeBuildpackValue = "my-cool-buildpack";
+            string expectedArgs = $"push \"{fakeAppName}\" -b {fakeBuildpackValue}"; // ensure app name gets surrounded by quotes
+
+            mockCmdProcessService.Setup(m => m.
+                RunCommand(_fakePathToCfExe, expectedArgs, fakeProjectPath, null, null))
+                    .Returns(fakeSuccessCmdResult);
+
+            var result = await _sut.PushAppAsync(fakeAppName, null, null, fakeProjectPath, buildpack: fakeBuildpackValue);
+
+            Assert.IsTrue(result.Succeeded);
+            Assert.IsNull(result.Explanation);
+            Assert.AreEqual(fakeSuccessCmdResult, result.CmdDetails);
+        }
+        
+        [TestMethod]
+        [TestCategory("PushApp")]
+        public async Task PushAppAsync_AddsMultipleFlags_WhenGivenMultipleOptionalParams()
+        {
+            var fakeAppName = "my fake app";
+            var fakeStackValue = "my-cool-stack";
+            var fakeBuildpackValue = "my-cool-buildpack";
+            string expectedArgs = $"push \"{fakeAppName}\" -b {fakeBuildpackValue} -s {fakeStackValue}"; // ensure app name gets surrounded by quotes
+
+            mockCmdProcessService.Setup(m => m.
+                RunCommand(_fakePathToCfExe, expectedArgs, fakeProjectPath, null, null))
+                    .Returns(fakeSuccessCmdResult);
+
+            var result = await _sut.PushAppAsync(fakeAppName, null, null, fakeProjectPath, buildpack: fakeBuildpackValue, stack: fakeStackValue);
+
+            Assert.IsTrue(result.Succeeded);
+            Assert.IsNull(result.Explanation);
+            Assert.AreEqual(fakeSuccessCmdResult, result.CmdDetails);
+        }
+        
         [TestCategory("PushApp")]
         public async Task PushAppAsync_ReturnsFailureResult_WhenCfExeCannotBeFound()
         {

--- a/Services/CfCli/CfCliService.cs
+++ b/Services/CfCli/CfCliService.cs
@@ -43,7 +43,7 @@ namespace Tanzu.Toolkit.VisualStudio.Services.CfCli
         public static string V6_StartAppCmd = "start";
         public static string V6_DeleteAppCmd = "delete -f"; // -f avoids confirmation prompt
         internal static string V6_GetOrgsRequestPath = "GET /v2/organizations";
-        internal static string V6_GetSpacesRequestPath = "GET /v2/spaces"; 
+        internal static string V6_GetSpacesRequestPath = "GET /v2/spaces";
         internal static string V6_GetAppsRequestPath = "GET /v2/spaces"; // not a typo; app info returned from /v2/spaces/:guid/apps
 
 
@@ -282,7 +282,7 @@ namespace Tanzu.Toolkit.VisualStudio.Services.CfCli
                 var appsResponses = GetJsonResponsePages<AppsApiV2Response>(content, V6_GetAppsRequestPath);
 
                 /* check for unsuccessful json parsing */
-                if (appsResponses == null || 
+                if (appsResponses == null ||
                     (appsResponses.Count > 0 && appsResponses[0].guid == null && appsResponses[0].name == null && appsResponses[0].services == null && appsResponses[0].apps == null))
                 {
                     _logger.Error($"GetAppsAsync() failed during response parsing. Used this delimeter: '{V6_GetAppsRequestPath}' to parse through: {cmdResult.CmdDetails.StdOut}");
@@ -352,9 +352,13 @@ namespace Tanzu.Toolkit.VisualStudio.Services.CfCli
         /// <param name="stdErrCallback"></param>
         /// <param name="appDir"></param>
         /// <returns></returns>
-        public async Task<DetailedResult> PushAppAsync(string appName, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string appDir)
+        public async Task<DetailedResult> PushAppAsync(string appName, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string appDir, string buildpack = null, string stack = null)
         {
             string args = $"push \"{appName}\"";
+
+            if (buildpack != null) args += $" -b {buildpack}";
+            if (stack != null) args += $" -s {stack}";
+
             var pushResult = await RunCfCommandAsync(args, stdOutCallback, stdErrCallback, appDir);
 
             return pushResult;

--- a/Services/CfCli/ICfCliService.cs
+++ b/Services/CfCli/ICfCliService.cs
@@ -24,6 +24,6 @@ namespace Tanzu.Toolkit.VisualStudio.Services.CfCli
         Task<DetailedResult> StopAppByNameAsync(string appName);
         Task<DetailedResult> StartAppByNameAsync(string appName);
         Task<DetailedResult> DeleteAppByNameAsync(string appName, bool removeMappedRoutes = true);
-        Task<DetailedResult> PushAppAsync(string appName, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string appDir);
+        Task<DetailedResult> PushAppAsync(string appName, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string appDir, string buildpack = null, string stack = null);
     }
 }

--- a/Services/CloudFoundry/CloudFoundryService.cs
+++ b/Services/CloudFoundry/CloudFoundryService.cs
@@ -507,14 +507,22 @@ namespace Tanzu.Toolkit.VisualStudio.Services.CloudFoundry
             };
         }
 
-        public async Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string appProjPath, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback)
+        public async Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string appProjPath, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback)
         {
             if (!_fileLocatorService.DirContainsFiles(appProjPath)) return new DetailedResult(false, emptyOutputDirMessage);
 
             DetailedResult cfTargetResult = await cfCliService.InvokeCfCliAsync(arguments: $"target -o {targetOrg.OrgName} -s {targetSpace.SpaceName}", stdOutCallback, stdErrCallback);
             if (!cfTargetResult.Succeeded) return new DetailedResult(false, $"Unable to target org '{targetOrg.OrgName}' or space '{targetSpace.SpaceName}'.\n{cfTargetResult.Explanation}");
 
-            DetailedResult cfPushResult = await cfCliService.PushAppAsync(appName, stdOutCallback, stdErrCallback, appProjPath);
+            string buildpack = null;
+            string stack = null;
+            if (fullFrameworkDeployment)
+            {
+                buildpack = "hwc_buildpack";
+                stack = "windows";
+            }
+
+            DetailedResult cfPushResult = await cfCliService.PushAppAsync(appName, stdOutCallback, stdErrCallback, appProjPath, buildpack, stack);
             if (!cfPushResult.Succeeded) return new DetailedResult(false, $"Successfully targeted org '{targetOrg.OrgName}' and space '{targetSpace.SpaceName}' but app deployment failed at the `cf push` stage.\n{cfPushResult.Explanation}");
 
             return new DetailedResult(true, $"App successfully deploying to org '{targetOrg.OrgName}', space '{targetSpace.SpaceName}'...");

--- a/Services/CloudFoundry/CloudFoundryService.cs
+++ b/Services/CloudFoundry/CloudFoundryService.cs
@@ -512,7 +512,11 @@ namespace Tanzu.Toolkit.VisualStudio.Services.CloudFoundry
             if (!_fileLocatorService.DirContainsFiles(appProjPath)) return new DetailedResult(false, emptyOutputDirMessage);
 
             DetailedResult cfTargetResult = await cfCliService.InvokeCfCliAsync(arguments: $"target -o {targetOrg.OrgName} -s {targetSpace.SpaceName}", stdOutCallback, stdErrCallback);
-            if (!cfTargetResult.Succeeded) return new DetailedResult(false, $"Unable to target org '{targetOrg.OrgName}' or space '{targetSpace.SpaceName}'.\n{cfTargetResult.Explanation}");
+            if (!cfTargetResult.Succeeded)
+            {
+                logger.Error($"Unable to target org '{targetOrg.OrgName}' or space '{targetSpace.SpaceName}'.\n{cfTargetResult.Explanation}");
+                return new DetailedResult(false, $"Unable to target org '{targetOrg.OrgName}' or space '{targetSpace.SpaceName}'.\n{cfTargetResult.Explanation}");
+            }
 
             string buildpack = null;
             string stack = null;
@@ -523,7 +527,11 @@ namespace Tanzu.Toolkit.VisualStudio.Services.CloudFoundry
             }
 
             DetailedResult cfPushResult = await cfCliService.PushAppAsync(appName, stdOutCallback, stdErrCallback, appProjPath, buildpack, stack);
-            if (!cfPushResult.Succeeded) return new DetailedResult(false, $"Successfully targeted org '{targetOrg.OrgName}' and space '{targetSpace.SpaceName}' but app deployment failed at the `cf push` stage.\n{cfPushResult.Explanation}");
+            if (!cfPushResult.Succeeded)
+            {
+                logger.Error($"Successfully targeted org '{targetOrg.OrgName}' and space '{targetSpace.SpaceName}' but app deployment failed at the `cf push` stage.\n{cfPushResult.Explanation}");
+                return new DetailedResult(false, cfPushResult.Explanation);
+            }
 
             return new DetailedResult(true, $"App successfully deploying to org '{targetOrg.OrgName}', space '{targetSpace.SpaceName}'...");
         }

--- a/Services/CloudFoundry/ICloudFoundryService.cs
+++ b/Services/CloudFoundry/ICloudFoundryService.cs
@@ -20,7 +20,7 @@ namespace Tanzu.Toolkit.VisualStudio.Services.CloudFoundry
         Task<DetailedResult> StopAppAsync(CloudFoundryApp app, bool skipSsl = true);
         Task<DetailedResult> StartAppAsync(CloudFoundryApp app, bool skipSsl = true);
         Task<DetailedResult> DeleteAppAsync(CloudFoundryApp app, bool skipSsl = true, bool removeRoutes = true);
-        Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string appProjPath, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback);
+        Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string appProjPath, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback);
         void RemoveCloudFoundryInstance(string name);
     }
 }

--- a/TanzuForVS/Commands/PushToCloudFoundryCommand.cs
+++ b/TanzuForVS/Commands/PushToCloudFoundryCommand.cs
@@ -1,14 +1,14 @@
 ﻿using EnvDTE;
 using EnvDTE80;
 using Microsoft;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.IO;
-using System.Threading.Tasks;
+using Tanzu.Toolkit.VisualStudio.Services.Dialog;
 using Tanzu.Toolkit.VisualStudio.ViewModels;
 using Tanzu.Toolkit.VisualStudio.WpfViews;
 using Task = System.Threading.Tasks.Task;
@@ -20,6 +20,8 @@ namespace Tanzu.Toolkit.VisualStudio.Commands
     /// </summary>
     internal sealed class PushToCloudFoundryCommand
     {
+        private IDialogService dialogService;
+
         /// <summary>
         /// Command ID.
         /// </summary>
@@ -49,6 +51,8 @@ namespace Tanzu.Toolkit.VisualStudio.Commands
             commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
 
             _services = services;
+
+            dialogService = services.GetRequiredService<IDialogService>();
 
             var menuCommandID = new CommandID(CommandSet, CommandId);
             var menuItem = new MenuCommand(Execute, menuCommandID);
@@ -115,21 +119,28 @@ namespace Tanzu.Toolkit.VisualStudio.Commands
                     string projectDirectory = Path.GetDirectoryName(proj.FullName);
 
                     string tfm = proj.Properties.Item("TargetFrameworkMoniker").Value.ToString();
-
-                    var viewModel = new DeploymentDialogViewModel(_services, projectDirectory, tfm);
-                    var view = new DeploymentDialogView(viewModel);
-
-                    var deployWindow = new DeploymentWindow
+                    if (tfm.StartsWith(".NETFramework") && !File.Exists(Path.Combine(projectDirectory, "Web.config")))
                     {
-                        Content = view
-                    };
-
-                    deployWindow.ShowModal();
-
-                    //* Actions to take after modal closes:
-                    if (viewModel.DeploymentInProgress) // don't open tool window if modal was closed via "X" button
+                        string msg = $"This project appears to target .NET Framework; deploying it to Tanzu Application Service requires a 'Web.config' file at it's base directory, but none was found in {projectDirectory}";
+                        dialogService.DisplayErrorDialog("Unable to deploy to Tanzu Application Service", msg);
+                    }
+                    else
                     {
-                        DisplayOutputToolWindow();
+                        var viewModel = new DeploymentDialogViewModel(_services, projectDirectory, tfm);
+                        var view = new DeploymentDialogView(viewModel);
+
+                        var deployWindow = new DeploymentWindow
+                        {
+                            Content = view
+                        };
+
+                        deployWindow.ShowModal();
+
+                        //* Actions to take after modal closes:
+                        if (viewModel.DeploymentInProgress) // don't open tool window if modal was closed via "X" button
+                        {
+                            DisplayOutputToolWindow();
+                        }
                     }
                 }
 
@@ -138,14 +149,7 @@ namespace Tanzu.Toolkit.VisualStudio.Commands
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                VsShellUtilities.ShowMessageBox(
-                    package,
-                    ex.ToString(),
-                            "Unable to push to Tanzu Application Service",
-                            OLEMSGICON.OLEMSGICON_CRITICAL,
-                            OLEMSGBUTTON.OLEMSGBUTTON_OK,
-                            OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST
-                        );
+                dialogService.DisplayErrorDialog("Unable to deploy to Tanzu Application Service", ex.Message);
             }
         }
 

--- a/ViewModel.Tests/DeploymentDialogViewModelTests.cs
+++ b/ViewModel.Tests/DeploymentDialogViewModelTests.cs
@@ -18,8 +18,10 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         private CloudFoundrySpace _fakeSpace = new CloudFoundrySpace("", "", _fakeOrg);
         private const string _fakeAppName = "fake app name";
         private const string _fakeProjPath = "this\\is\\a\\fake\\path\\to\\a\\project\\directory";
-        private DeploymentDialogViewModel _sut;
+        private const string fakeTargetFrameworkMoniker = "junk";
+        private DeploymentDialogViewModel sut;
         private List<string> _receivedEvents;
+        private bool defaultFullFWFlag = false;
 
         [TestInitialize]
         public void TestInit()
@@ -34,10 +36,10 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
                 mock.NavigateTo(nameof(OutputViewModel), null))
                     .Returns(new FakeOutputView());
 
-            _sut = new DeploymentDialogViewModel(services, _fakeProjPath);
+            sut = new DeploymentDialogViewModel(services, _fakeProjPath, fakeTargetFrameworkMoniker);
 
             _receivedEvents = new List<string>();
-            _sut.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
+            sut.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
             {
                 _receivedEvents.Add(e.PropertyName);
             };
@@ -54,7 +56,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod()]
         public void DeploymentDialogViewModel_GetsListOfCfsFromCfService_WhenConstructed()
         {
-            var vm = new DeploymentDialogViewModel(services, _fakeProjPath);
+            var vm = new DeploymentDialogViewModel(services, _fakeProjPath, fakeTargetFrameworkMoniker);
 
             Assert.IsNotNull(vm.CfInstanceOptions);
             Assert.AreEqual(0, vm.CfInstanceOptions.Count);
@@ -65,7 +67,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod()]
         public void DeploymentDialogViewModel_SetsCfOrgOptionsToEmptyList_WhenConstructed()
         {
-            var vm = new DeploymentDialogViewModel(services, _fakeProjPath);
+            var vm = new DeploymentDialogViewModel(services, _fakeProjPath, fakeTargetFrameworkMoniker);
 
             Assert.IsNotNull(vm.CfOrgOptions);
             Assert.AreEqual(0, vm.CfOrgOptions.Count);
@@ -74,94 +76,95 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod()]
         public void DeploymentDialogViewModel_SetsCfSpaceOptionsToEmptyList_WhenConstructed()
         {
-            var vm = new DeploymentDialogViewModel(services, _fakeProjPath);
+            var vm = new DeploymentDialogViewModel(services, _fakeProjPath, fakeTargetFrameworkMoniker);
 
             Assert.IsNotNull(vm.CfSpaceOptions);
             Assert.AreEqual(0, vm.CfSpaceOptions.Count);
         }
 
+
         [TestMethod]
         public void DeployApp_UpdatesDeploymentStatus_WhenAppNameEmpty()
         {
             var receivedEvents = new List<string>();
-            _sut.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
+            sut.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
             {
                 receivedEvents.Add(e.PropertyName);
             };
 
-            _sut.AppName = string.Empty;
-            _sut.SelectedCf = _fakeCfInstance;
-            _sut.SelectedOrg = _fakeOrg;
-            _sut.SelectedSpace = _fakeSpace;
+            sut.AppName = string.Empty;
+            sut.SelectedCf = _fakeCfInstance;
+            sut.SelectedOrg = _fakeOrg;
+            sut.SelectedSpace = _fakeSpace;
 
-            _sut.DeployApp(null);
+            sut.DeployApp(null);
 
             Assert.IsTrue(receivedEvents.Contains("DeploymentStatus"));
-            Assert.IsTrue(_sut.DeploymentStatus.Contains("An error occurred:"));
-            Assert.IsTrue(_sut.DeploymentStatus.Contains(DeploymentDialogViewModel.appNameEmptyMsg));
+            Assert.IsTrue(sut.DeploymentStatus.Contains("An error occurred:"));
+            Assert.IsTrue(sut.DeploymentStatus.Contains(DeploymentDialogViewModel.appNameEmptyMsg));
         }
 
         [TestMethod]
         public void DeployApp_UpdatesDeploymentStatus_WhenTargetCfEmpty()
         {
             var receivedEvents = new List<string>();
-            _sut.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
+            sut.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
             {
                 receivedEvents.Add(e.PropertyName);
             };
 
-            _sut.AppName = "fake app name";
-            _sut.SelectedCf = null;
-            _sut.SelectedOrg = _fakeOrg;
-            _sut.SelectedSpace = _fakeSpace;
+            sut.AppName = "fake app name";
+            sut.SelectedCf = null;
+            sut.SelectedOrg = _fakeOrg;
+            sut.SelectedSpace = _fakeSpace;
 
-            _sut.DeployApp(null);
+            sut.DeployApp(null);
 
             Assert.IsTrue(receivedEvents.Contains("DeploymentStatus"));
-            Assert.IsTrue(_sut.DeploymentStatus.Contains("An error occurred:"));
-            Assert.IsTrue(_sut.DeploymentStatus.Contains(DeploymentDialogViewModel.targetEmptyMsg));
+            Assert.IsTrue(sut.DeploymentStatus.Contains("An error occurred:"));
+            Assert.IsTrue(sut.DeploymentStatus.Contains(DeploymentDialogViewModel.targetEmptyMsg));
         }
 
         [TestMethod]
         public void DeployApp_UpdatesDeploymentStatus_WhenTargetOrgEmpty()
         {
             var receivedEvents = new List<string>();
-            _sut.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
+            sut.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
             {
                 receivedEvents.Add(e.PropertyName);
             };
 
-            _sut.AppName = "fake app name";
-            _sut.SelectedCf = _fakeCfInstance;
-            _sut.SelectedOrg = null;
-            _sut.SelectedSpace = _fakeSpace;
+            sut.AppName = "fake app name";
+            sut.SelectedCf = _fakeCfInstance;
+            sut.SelectedOrg = null;
+            sut.SelectedSpace = _fakeSpace;
 
-            _sut.DeployApp(null);
+            sut.DeployApp(null);
 
             Assert.IsTrue(receivedEvents.Contains("DeploymentStatus"));
-            Assert.IsTrue(_sut.DeploymentStatus.Contains("An error occurred:"));
-            Assert.IsTrue(_sut.DeploymentStatus.Contains(DeploymentDialogViewModel.orgEmptyMsg));
+            Assert.IsTrue(sut.DeploymentStatus.Contains("An error occurred:"));
+            Assert.IsTrue(sut.DeploymentStatus.Contains(DeploymentDialogViewModel.orgEmptyMsg));
         }
 
         [TestMethod]
         public void DeployApp_UpdatesDeploymentStatus_WhenTargetSpaceEmpty()
         {
             var receivedEvents = new List<string>();
-            _sut.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
+            sut.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
             {
                 receivedEvents.Add(e.PropertyName);
             };
 
-            _sut.AppName = "fake app name";
-            _sut.SelectedCf = _fakeCfInstance;
-            _sut.SelectedOrg = _fakeOrg;
-            _sut.SelectedSpace = null;
+            sut.AppName = "fake app name";
+            sut.SelectedCf = _fakeCfInstance;
+            sut.SelectedOrg = _fakeOrg;
+            sut.SelectedSpace = null;
 
-            _sut.DeployApp(null);
+            sut.DeployApp(null);
 
             Assert.IsTrue(receivedEvents.Contains("DeploymentStatus"));
-            Assert.IsTrue(_sut.DeploymentStatus.Contains("An error occurred:"));
-            Assert.IsTrue(_sut.DeploymentStatus.Contains(DeploymentDialogViewModel.spaceEmptyMsg));
+            Assert.IsTrue(sut.DeploymentStatus.Contains("An error occurred:"));
+            Assert.IsTrue(sut.DeploymentStatus.Contains(DeploymentDialogViewModel.spaceEmptyMsg));
         }
 
         [TestMethod]
@@ -169,75 +172,101 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         {
             var dw = new object();
 
-            _sut.AppName = _fakeAppName;
-            _sut.SelectedCf = _fakeCfInstance;
-            _sut.SelectedOrg = _fakeOrg;
-            _sut.SelectedSpace = _fakeSpace;
+            sut.AppName = _fakeAppName;
+            sut.SelectedCf = _fakeCfInstance;
+            sut.SelectedOrg = _fakeOrg;
+            sut.SelectedSpace = _fakeSpace;
 
-            _sut.DeployApp(dw);
+            sut.DeployApp(dw);
             mockDialogService.Verify(mock => mock.CloseDialog(dw, true), Times.Once);
+        }
+
+        [TestMethod()]
+        public async Task DeploymentDialogViewModel_IndicatesFullFWDeployment_WhenTFMStartsWith_NETFramework()
+        {
+            string targetFrameworkMoniker = ".NETFramework";
+            sut = new DeploymentDialogViewModel(services, _fakeProjPath, targetFrameworkMoniker)
+            {
+                AppName = _fakeAppName,
+                SelectedCf = _fakeCfInstance,
+                SelectedOrg = _fakeOrg,
+                SelectedSpace = _fakeSpace
+            };
+
+            bool expectedFullFWFlag = true;
+
+            mockCloudFoundryService.Setup(m => m.
+                DeployAppAsync(_fakeCfInstance, _fakeOrg, _fakeSpace, _fakeAppName, _fakeProjPath,
+                    expectedFullFWFlag,
+                    It.IsAny<StdOutDelegate>(),
+                    It.IsAny<StdErrDelegate>()))
+                .ReturnsAsync(fakeSuccessDetailedResult);
+            
+            await sut.StartDeployment();
+
+            mockCloudFoundryService.VerifyAll();
         }
 
         [TestMethod]
         public async Task StartDeploymentTask_UpdatesDeploymentInProgress_WhenComplete()
         {
             var receivedEvents = new List<string>();
-            _sut.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
+            sut.PropertyChanged += delegate (object sender, PropertyChangedEventArgs e)
             {
                 receivedEvents.Add(e.PropertyName);
             };
 
             mockCloudFoundryService.Setup(mock =>
-                mock.DeployAppAsync(_fakeCfInstance, _fakeOrg, _fakeSpace, _fakeAppName, _fakeProjPath,
+                mock.DeployAppAsync(_fakeCfInstance, _fakeOrg, _fakeSpace, _fakeAppName, _fakeProjPath, defaultFullFWFlag,
                                     It.IsAny<StdOutDelegate>(),
                                     It.IsAny<StdErrDelegate>()))
                     .ReturnsAsync(fakeSuccessDetailedResult);
 
-            _sut.AppName = _fakeAppName;
-            _sut.SelectedCf = _fakeCfInstance;
-            _sut.SelectedOrg = _fakeOrg;
-            _sut.SelectedSpace = _fakeSpace;
+            sut.AppName = _fakeAppName;
+            sut.SelectedCf = _fakeCfInstance;
+            sut.SelectedOrg = _fakeOrg;
+            sut.SelectedSpace = _fakeSpace;
 
-            _sut.DeploymentInProgress = true;
+            sut.DeploymentInProgress = true;
 
-            await _sut.StartDeployment();
+            await sut.StartDeployment();
 
-            Assert.IsFalse(_sut.DeploymentInProgress);
+            Assert.IsFalse(sut.DeploymentInProgress);
         }
 
         [TestMethod]
         public async Task StartDeploymentTask_PassesOutputViewModelAppendLineMethod_AsCallbacks()
         {
-            _sut.AppName = _fakeAppName;
-            _sut.SelectedCf = _fakeCfInstance;
-            _sut.SelectedOrg = _fakeOrg;
-            _sut.SelectedSpace = _fakeSpace;
+            sut.AppName = _fakeAppName;
+            sut.SelectedCf = _fakeCfInstance;
+            sut.SelectedOrg = _fakeOrg;
+            sut.SelectedSpace = _fakeSpace;
 
-            StdOutDelegate expectedStdOutCallback = _sut.outputViewModel.AppendLine;
-            StdErrDelegate expectedStdErrCallback = _sut.outputViewModel.AppendLine;
+            StdOutDelegate expectedStdOutCallback = sut.outputViewModel.AppendLine;
+            StdErrDelegate expectedStdErrCallback = sut.outputViewModel.AppendLine;
 
             mockCloudFoundryService.Setup(mock => mock.
-              DeployAppAsync(_fakeCfInstance, _fakeOrg, _fakeSpace, _fakeAppName, _fakeProjPath,
+              DeployAppAsync(_fakeCfInstance, _fakeOrg, _fakeSpace, _fakeAppName, _fakeProjPath, defaultFullFWFlag,
                              expectedStdOutCallback,
                              expectedStdErrCallback))
                 .ReturnsAsync(fakeSuccessDetailedResult);
 
-            await _sut.StartDeployment();
+            await sut.StartDeployment();
         }
 
         [TestMethod]
         public async Task StartDeploymentTask_LogsError_WhenDeployResultReportsFailure()
         {
-            _sut.AppName = _fakeAppName;
-            _sut.SelectedCf = _fakeCfInstance;
-            _sut.SelectedOrg = _fakeOrg;
-            _sut.SelectedSpace = _fakeSpace;
+            sut.AppName = _fakeAppName;
+            sut.SelectedCf = _fakeCfInstance;
+            sut.SelectedOrg = _fakeOrg;
+            sut.SelectedSpace = _fakeSpace;
 
-            StdOutDelegate expectedStdOutCallback = _sut.outputViewModel.AppendLine;
-            StdErrDelegate expectedStdErrCallback = _sut.outputViewModel.AppendLine;
+            StdOutDelegate expectedStdOutCallback = sut.outputViewModel.AppendLine;
+            StdErrDelegate expectedStdErrCallback = sut.outputViewModel.AppendLine;
 
             mockCloudFoundryService.Setup(mock => mock.
-                DeployAppAsync(_fakeCfInstance, _fakeOrg, _fakeSpace, _fakeAppName, _fakeProjPath,
+                DeployAppAsync(_fakeCfInstance, _fakeOrg, _fakeSpace, _fakeAppName, _fakeProjPath, defaultFullFWFlag,
                              expectedStdOutCallback,
                              expectedStdErrCallback))
                     .ReturnsAsync(fakeFailureDetailedResult);
@@ -248,7 +277,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
             mockDialogService.Setup(mock => mock.
                 DisplayErrorDialog(expectedErrorTitle, expectedErrorMsg));
 
-            await _sut.StartDeployment();
+            await sut.StartDeployment();
 
             var logPropVal1 = "{AppName}";
             var logPropVal2 = "{TargetApi}";
@@ -265,16 +294,16 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public async Task StartDeploymentTask_DisplaysErrorDialog_WhenDeployResultReportsFailure()
         {
-            _sut.AppName = _fakeAppName;
-            _sut.SelectedCf = _fakeCfInstance;
-            _sut.SelectedOrg = _fakeOrg;
-            _sut.SelectedSpace = _fakeSpace;
+            sut.AppName = _fakeAppName;
+            sut.SelectedCf = _fakeCfInstance;
+            sut.SelectedOrg = _fakeOrg;
+            sut.SelectedSpace = _fakeSpace;
 
-            StdOutDelegate expectedStdOutCallback = _sut.outputViewModel.AppendLine;
-            StdErrDelegate expectedStdErrCallback = _sut.outputViewModel.AppendLine;
+            StdOutDelegate expectedStdOutCallback = sut.outputViewModel.AppendLine;
+            StdErrDelegate expectedStdErrCallback = sut.outputViewModel.AppendLine;
 
             mockCloudFoundryService.Setup(mock => mock.
-                DeployAppAsync(_fakeCfInstance, _fakeOrg, _fakeSpace, _fakeAppName, _fakeProjPath,
+                DeployAppAsync(_fakeCfInstance, _fakeOrg, _fakeSpace, _fakeAppName, _fakeProjPath, defaultFullFWFlag,
                              expectedStdOutCallback,
                              expectedStdErrCallback))
                     .ReturnsAsync(fakeFailureDetailedResult);
@@ -285,7 +314,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
             mockDialogService.Setup(mock => mock.
                 DisplayErrorDialog(expectedErrorTitle, expectedErrorMsg));
 
-            await _sut.StartDeployment();
+            await sut.StartDeployment();
         }
 
         [TestMethod]
@@ -303,14 +332,14 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
                 GetOrgsForCfInstanceAsync(fakeCfInstance, true))
                     .ReturnsAsync(fakeSuccessfulOrgsResponse);
 
-            _sut.SelectedCf = fakeCfInstance;
+            sut.SelectedCf = fakeCfInstance;
 
-            Assert.AreEqual(0, _sut.CfOrgOptions.Count);
+            Assert.AreEqual(0, sut.CfOrgOptions.Count);
 
-            await _sut.UpdateCfOrgOptions();
+            await sut.UpdateCfOrgOptions();
 
-            Assert.AreEqual(1, _sut.CfOrgOptions.Count);
-            Assert.AreEqual(fakeCfOrg, _sut.CfOrgOptions[0]);
+            Assert.AreEqual(1, sut.CfOrgOptions.Count);
+            Assert.AreEqual(fakeCfOrg, sut.CfOrgOptions[0]);
 
             Assert.IsTrue(_receivedEvents.Contains("CfOrgOptions"));
         }
@@ -318,11 +347,11 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public async Task UpdateCfOrgOptions_SetsCfOrgOptionsToEmptyList_WhenSelectedCfIsNull()
         {
-            _sut.SelectedCf = null;
+            sut.SelectedCf = null;
 
-            await _sut.UpdateCfOrgOptions();
+            await sut.UpdateCfOrgOptions();
 
-            Assert.AreEqual(0, _sut.CfOrgOptions.Count);
+            Assert.AreEqual(0, sut.CfOrgOptions.Count);
 
             Assert.IsTrue(_receivedEvents.Contains("CfOrgOptions"));
         }
@@ -345,13 +374,13 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
             mockDialogService.Setup(mock => mock.
                 DisplayErrorDialog(DeploymentDialogViewModel.getOrgsFailureMsg, fakeExplanation));
 
-            _sut.SelectedCf = fakeCfInstance;
-            var initialOrgOptions = _sut.CfOrgOptions;
+            sut.SelectedCf = fakeCfInstance;
+            var initialOrgOptions = sut.CfOrgOptions;
 
-            await _sut.UpdateCfOrgOptions();
+            await sut.UpdateCfOrgOptions();
 
             mockDialogService.VerifyAll();
-            Assert.AreEqual(initialOrgOptions, _sut.CfOrgOptions);
+            Assert.AreEqual(initialOrgOptions, sut.CfOrgOptions);
         }
         
         [TestMethod]
@@ -372,10 +401,10 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
             mockDialogService.Setup(mock => mock.
                 DisplayErrorDialog(DeploymentDialogViewModel.getOrgsFailureMsg, fakeExplanation));
 
-            _sut.SelectedCf = fakeCfInstance;
-            var initialOrgOptions = _sut.CfOrgOptions;
+            sut.SelectedCf = fakeCfInstance;
+            var initialOrgOptions = sut.CfOrgOptions;
 
-            await _sut.UpdateCfOrgOptions();
+            await sut.UpdateCfOrgOptions();
 
             mockLogger.Verify(m => m.
                 Error($"{DeploymentDialogViewModel.getOrgsFailureMsg}. {fakeFailedOrgsResponse}"),
@@ -398,15 +427,15 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
                 GetSpacesForOrgAsync(fakeCfOrg, true))
                     .ReturnsAsync(fakeSuccessfulSpacesResponse);
 
-            _sut.SelectedCf = fakeCfInstance;
-            _sut.SelectedOrg = fakeCfOrg;
+            sut.SelectedCf = fakeCfInstance;
+            sut.SelectedOrg = fakeCfOrg;
 
-            Assert.AreEqual(0, _sut.CfSpaceOptions.Count);
+            Assert.AreEqual(0, sut.CfSpaceOptions.Count);
 
-            await _sut.UpdateCfSpaceOptions();
+            await sut.UpdateCfSpaceOptions();
 
-            Assert.AreEqual(1, _sut.CfSpaceOptions.Count);
-            Assert.AreEqual(fakeCfSpace, _sut.CfSpaceOptions[0]);
+            Assert.AreEqual(1, sut.CfSpaceOptions.Count);
+            Assert.AreEqual(fakeCfSpace, sut.CfSpaceOptions[0]);
 
             Assert.IsTrue(_receivedEvents.Contains("CfSpaceOptions"));
         }
@@ -414,11 +443,11 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public async Task UpdateCfSpaceOptions_SetsCfSpaceOptionsToEmptyList_WhenSelectedCfIsNull()
         {
-            _sut.SelectedCf = null;
+            sut.SelectedCf = null;
 
-            await _sut.UpdateCfSpaceOptions();
+            await sut.UpdateCfSpaceOptions();
 
-            Assert.AreEqual(0, _sut.CfSpaceOptions.Count);
+            Assert.AreEqual(0, sut.CfSpaceOptions.Count);
 
             Assert.IsTrue(_receivedEvents.Contains("CfSpaceOptions"));
         }
@@ -426,11 +455,11 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
         [TestMethod]
         public async Task UpdateCfSpaceOptions_SetsCfSpaceOptionsToEmptyList_WhenSelectedOrgIsNull()
         {
-            _sut.SelectedOrg = null;
+            sut.SelectedOrg = null;
 
-            await _sut.UpdateCfSpaceOptions();
+            await sut.UpdateCfSpaceOptions();
 
-            Assert.AreEqual(0, _sut.CfSpaceOptions.Count);
+            Assert.AreEqual(0, sut.CfSpaceOptions.Count);
 
             Assert.IsTrue(_receivedEvents.Contains("CfSpaceOptions"));
         }
@@ -453,11 +482,11 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
             mockDialogService.Setup(mock => mock.
                 DisplayErrorDialog(DeploymentDialogViewModel.getSpacesFailureMsg, fakeExplanation));
 
-            _sut.SelectedCf = fakeCfInstance;
-            _sut.SelectedOrg = fakeCfOrg;
-            var initialSpaceOptions = _sut.CfSpaceOptions;
+            sut.SelectedCf = fakeCfInstance;
+            sut.SelectedOrg = fakeCfOrg;
+            var initialSpaceOptions = sut.CfSpaceOptions;
 
-            await _sut.UpdateCfSpaceOptions();
+            await sut.UpdateCfSpaceOptions();
 
             mockLogger.Verify(m => m.
                 Error($"{DeploymentDialogViewModel.getSpacesFailureMsg}. {fakeFailedSpacesResponse}"),
@@ -482,14 +511,14 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels.Tests
             mockDialogService.Setup(mock => mock.
                 DisplayErrorDialog(DeploymentDialogViewModel.getSpacesFailureMsg, fakeExplanation));
 
-            _sut.SelectedCf = fakeCfInstance;
-            _sut.SelectedOrg = fakeCfOrg;
-            var initialSpaceOptions = _sut.CfSpaceOptions;
+            sut.SelectedCf = fakeCfInstance;
+            sut.SelectedOrg = fakeCfOrg;
+            var initialSpaceOptions = sut.CfSpaceOptions;
 
-            await _sut.UpdateCfSpaceOptions();
+            await sut.UpdateCfSpaceOptions();
 
             mockDialogService.VerifyAll();
-            Assert.AreEqual(initialSpaceOptions, _sut.CfSpaceOptions);
+            Assert.AreEqual(initialSpaceOptions, sut.CfSpaceOptions);
         }
 
     }

--- a/ViewModels/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/ViewModels/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -19,19 +19,24 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels
         internal const string deploymentErrorMsg = "Unable to deploy app:";
         internal const string getOrgsFailureMsg = "Unable to fetch orgs.";
         internal const string getSpacesFailureMsg = "Unable to fetch spaces.";
+
         private readonly string projDir;
+        private readonly string projTargetFramework;
         private string status;
         private string appName;
+        private readonly bool fullFrameworkDeployment = false;
+
         private List<CloudFoundryInstance> cfInstances;
         private List<CloudFoundryOrganization> cfOrgs;
         private List<CloudFoundrySpace> cfSpaces;
         private CloudFoundryInstance selectedCf;
         private CloudFoundryOrganization selectedOrg;
         private CloudFoundrySpace selectedSpace;
+
         internal IOutputViewModel outputViewModel;
 
 
-        public DeploymentDialogViewModel(IServiceProvider services, string directoryOfProjectToDeploy)
+        public DeploymentDialogViewModel(IServiceProvider services, string directoryOfProjectToDeploy, string targetFrameworkMoniker)
             : base(services)
         {
             IView outputView = ViewLocatorService.NavigateTo(nameof(OutputViewModel)) as IView;
@@ -42,6 +47,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels
             SelectedCf = null;
             projDir = directoryOfProjectToDeploy;
 
+            if (targetFrameworkMoniker.StartsWith(".NETFramework")) fullFrameworkDeployment = true;
 
             UpdateCfInstanceOptions();
             CfOrgOptions = new List<CloudFoundryOrganization>();
@@ -197,6 +203,7 @@ namespace Tanzu.Toolkit.VisualStudio.ViewModels
                 SelectedSpace,
                 AppName,
                 projDir,
+                fullFrameworkDeployment,
                 stdOutCallback: outputViewModel.AppendLine,
                 stdErrCallback: outputViewModel.AppendLine
             );


### PR DESCRIPTION
1. Use EnvDTE Project "TargetFrameworkMoniker" Property to identify when an app targets .NET Framework 
2. Indicate to DeploymentDialogViewModel that the desired deployment is for a .NET Framework app
3. Signal to CloudFoundryService that the deployment command should contain extra (.NET FW-specific) parameters 
4. Specify the proper buildpack & stack by attaching `-b hwc_buildpack -s windows` to the `cf push` command

_(Added bonus):_ 
Receive an error message if you try to deploy a .NET Framework app which is missing a `Web.config` file in its base directory.
(In the future, we could offer to generate a boilerplate `Web.config` for anyone who tries to deploy a FW app without one)