### PR TITLE
Improve Cloud Explorer refresh behavior

### DIFF
--- a/src/Services/src/IUiDispatcherService.cs
+++ b/src/Services/src/IUiDispatcherService.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Tanzu.Toolkit.Services
+{
+    public interface IUiDispatcherService
+    {
+        void RunOnUiThread(Action method);
+    }
+}

--- a/src/ViewModels/src/AbstractViewModel.cs
+++ b/src/ViewModels/src/AbstractViewModel.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
+using Tanzu.Toolkit.Services;
 using Tanzu.Toolkit.Services.CloudFoundry;
 using Tanzu.Toolkit.Services.Dialog;
 using Tanzu.Toolkit.Services.Logging;
@@ -21,6 +22,7 @@ namespace Tanzu.Toolkit.ViewModels
             CloudFoundryService = services.GetRequiredService<ICloudFoundryService>();
             DialogService = services.GetRequiredService<IDialogService>();
             ViewLocatorService = services.GetRequiredService<IViewLocatorService>();
+            UiDispatcherService = services.GetRequiredService<IUiDispatcherService>();
             var logSvc = services.GetRequiredService<ILoggingService>();
             Logger = logSvc.Logger;
         }
@@ -30,6 +32,8 @@ namespace Tanzu.Toolkit.ViewModels
         public ICloudFoundryService CloudFoundryService { get; }
 
         public IViewLocatorService ViewLocatorService { get; }
+        
+        public IUiDispatcherService UiDispatcherService { get; }
 
         public IDialogService DialogService { get; }
 

--- a/src/ViewModels/src/CloudExplorer/CloudExplorerViewModel.cs
+++ b/src/ViewModels/src/CloudExplorer/CloudExplorerViewModel.cs
@@ -1,9 +1,12 @@
-﻿using System;
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Tanzu.Toolkit.Models;
+using Tanzu.Toolkit.Services.Threading;
 
 namespace Tanzu.Toolkit.ViewModels
 {
@@ -15,12 +18,16 @@ namespace Tanzu.Toolkit.ViewModels
 
         private bool _hasCloudTargets;
         private ObservableCollection<CfInstanceViewModel> _cfs;
+        private bool isRefreshingAll = false;
         private readonly IServiceProvider _services;
+        private readonly IThreadingService _threadingService;
 
         public CloudExplorerViewModel(IServiceProvider services)
             : base(services)
         {
             _services = services;
+            _threadingService = services.GetRequiredService<IThreadingService>();
+
             _cfs = new ObservableCollection<CfInstanceViewModel>();
             HasCloudTargets = CloudFoundryService.CloudFoundryInstances.Keys.Count > 0;
         }
@@ -44,6 +51,17 @@ namespace Tanzu.Toolkit.ViewModels
             {
                 _hasCloudTargets = value;
                 RaisePropertyChangedEvent("HasCloudTargets");
+            }
+        }
+
+        public bool IsRefreshingAll
+        {
+            get => isRefreshingAll;
+
+            internal set
+            {
+                isRefreshingAll = value;
+                RaisePropertyChangedEvent("IsRefreshingAll");
             }
         }
 
@@ -87,7 +105,7 @@ namespace Tanzu.Toolkit.ViewModels
             return true;
         }
 
-        public bool CanRefreshAllCloudConnections(object arg)
+        public bool CanInitiateFullRefresh(object arg)
         {
             return true;
         }
@@ -185,138 +203,121 @@ namespace Tanzu.Toolkit.ViewModels
             }
         }
 
-        public async Task RefreshCfInstance(object cfInstanceViewModel)
+        public void RefreshSpace(object arg)
         {
-            if (cfInstanceViewModel is CfInstanceViewModel cfivm)
+            if (arg is SpaceViewModel spaceViewModel)
             {
-                var currentOrgs = await cfivm.FetchChildren();
-
-                RemoveNonexistentOrgs(cfivm, currentOrgs);
-                AddNewOrgs(cfivm, currentOrgs);
-
-                if (cfivm.Children.Count == 0)
-                {
-                    cfivm.Children.Add(cfivm.EmptyPlaceholder);
-                }
-                else if (cfivm.Children.Count > 1 && cfivm.HasEmptyPlaceholder)
-                {
-                    cfivm.Children.Remove(cfivm.EmptyPlaceholder);
-                }
+                Task.Run(() => spaceViewModel.RefreshChildren());
             }
         }
 
-        public async Task RefreshOrg(object orgViewModel)
+        public void RefreshAllItems(object arg)
         {
-            if (orgViewModel is OrgViewModel ovm)
+            if (!IsRefreshingAll)
             {
-                var currentSpaces = await ovm.FetchChildren();
-
-                RemoveNonexistentSpaces(ovm, currentSpaces);
-                AddNewSpaces(ovm, currentSpaces);
-
-                if (ovm.Children.Count == 0)
-                {
-                    ovm.Children.Add(ovm.EmptyPlaceholder);
-                }
-                else if (ovm.Children.Count > 1 && ovm.HasEmptyPlaceholder)
-                {
-                    ovm.Children.Remove(ovm.EmptyPlaceholder);
-                }
+                _threadingService.StartTask(InitiateFullRefresh);
             }
         }
 
-        public async Task RefreshSpace(object spaceViewModel)
+        internal async Task InitiateFullRefresh()
         {
-            if (spaceViewModel is SpaceViewModel svm)
+            await Task.Run(() =>
             {
-                var currentApps = await svm.FetchChildren();
+                IsRefreshingAll = true;
 
-                RemoveNonexistentApps(svm, currentApps);
-                AddNewApps(svm, currentApps);
+                // before refreshing each cf instance, check the Model's record of Cloud
+                // connections & make sure `CloudFoundryList` matches those values
+                SyncCloudFoundryList();
 
-                if (svm.Children.Count == 0)
+                object threadLock = new object();
+                int numThreads = 0;
+
+                foreach (CfInstanceViewModel cfivm in CloudFoundryList)
                 {
-                    svm.Children.Add(svm.EmptyPlaceholder);
-                }
-                else if (svm.Children.Count > 1 && svm.HasEmptyPlaceholder)
-                {
-                    svm.Children.Remove(svm.EmptyPlaceholder);
-                }
-            }
-        }
-
-        public void RefreshApp(object appViewModel)
-        {
-            if (appViewModel is AppViewModel avm)
-            {
-                avm.SignalIsStoppedChanged();
-            }
-        }
-
-        public async Task RefreshAllCloudConnections(object arg)
-        {
-            // record original items before refreshing starts to
-            // avoid unnecessary LoadChildren calls for *new* items
-            var initalIds = new List<string>();
-
-            foreach (CfInstanceViewModel cfivm in CloudFoundryList)
-            {
-                initalIds.Add(cfivm.CloudFoundryInstance.InstanceId);
-
-                foreach (TreeViewItemViewModel cfChild in cfivm.Children)
-                {
-                    if (cfChild is OrgViewModel ovm)
+                    if (cfivm.IsExpanded)
                     {
-                        initalIds.Add(ovm.Org.OrgId);
-
-                        foreach (TreeViewItemViewModel orgChild in ovm.Children)
+                        var refreshCfTask = new Task(async () =>
                         {
-                            if (orgChild is SpaceViewModel svm)
+                            await cfivm.RefreshChildren();
+
+                            foreach (TreeViewItemViewModel cfChild in cfivm.Children)
                             {
-                                initalIds.Add(svm.Space.SpaceId);
-                            }
-                        }
-                    }
-                }
-            }
-
-            // before refreshing each cf instance, check the Model's record of Cloud
-            // connections & make sure `CloudFoundryList` matches those values
-            SyncCloudFoundryList();
-
-            foreach (CfInstanceViewModel cfivm in CloudFoundryList)
-            {
-                bool cfNotNew = initalIds.Contains(cfivm.CloudFoundryInstance.InstanceId);
-
-                if (cfNotNew)
-                {
-                    await RefreshCfInstance(cfivm);
-
-                    foreach (TreeViewItemViewModel cfChild in cfivm.Children)
-                    {
-                        if (cfChild is OrgViewModel ovm && initalIds.Contains(ovm.Org.OrgId))
-                        {
-                            await RefreshOrg(ovm);
-
-                            foreach (TreeViewItemViewModel orgChild in ovm.Children)
-                            {
-                                if (orgChild is SpaceViewModel svm && initalIds.Contains(svm.Space.SpaceId))
+                                if (cfChild is OrgViewModel ovm && cfChild.IsExpanded)
                                 {
-                                    await RefreshSpace(svm);
-
-                                    foreach (TreeViewItemViewModel spaceChild in svm.Children)
+                                    var refreshOrgTask = new Task(async () =>
                                     {
-                                        if (spaceChild is AppViewModel avm)
+                                        await ovm.RefreshChildren();
+
+                                        foreach (TreeViewItemViewModel orgChild in ovm.Children)
                                         {
-                                            RefreshApp(avm);
+                                            if (orgChild is SpaceViewModel svm && orgChild.IsExpanded)
+                                            {
+                                                var refreshSpaceTask = new Task(async () =>
+                                                {
+                                                    await svm.RefreshChildren();
+
+                                                    lock (threadLock)
+                                                    {
+                                                        if (numThreads < 1) throw new ArgumentOutOfRangeException();
+                                                        numThreads -= 1;
+                                                    }
+                                                });
+
+                                                lock (threadLock)
+                                                {
+                                                    numThreads += 1;
+                                                }
+
+                                                _threadingService.StartTask(() => Task.Run(() => refreshSpaceTask.Start())); // wrapped in extra task runner for ease of unit testing
+                                            }
                                         }
+
+                                        lock (threadLock)
+                                        {
+                                            if (numThreads < 1) throw new ArgumentOutOfRangeException();
+                                            numThreads -= 1;
+                                        }
+                                    });
+
+                                    lock (threadLock)
+                                    {
+                                        numThreads += 1;
                                     }
+
+                                    _threadingService.StartTask(() => Task.Run(() => refreshOrgTask.Start())); // wrapped in extra task runner for ease of unit testing
                                 }
                             }
+
+                            lock (threadLock)
+                            {
+                                if (numThreads < 1) throw new ArgumentOutOfRangeException();
+                                numThreads -= 1;
+                            }
+                        });
+
+                        lock (threadLock)
+                        {
+                            numThreads += 1;
                         }
+
+                        _threadingService.StartTask(() => Task.Run(() => refreshCfTask.Start())); // wrapped in extra task runner for ease of unit testing
                     }
                 }
-            }
+
+                int threadsStillRunning = 1;
+                int waitTime = 100;
+                while (threadsStillRunning > 0)
+                {
+                    lock (threadLock)
+                    {
+                        threadsStillRunning = numThreads;
+                    }
+
+                    Thread.Sleep(waitTime);
+                }
+
+                IsRefreshingAll = false;
+            });
         }
 
         public void RemoveCloudConnection(object arg)
@@ -363,7 +364,7 @@ namespace Tanzu.Toolkit.ViewModels
 
                     if (!cfWasAlreadyInCloudFoundryList)
                     {
-                        CloudFoundryList.Add(newCFIVM);
+                        UiDispatcherService.RunOnUiThread(() => CloudFoundryList.Add(newCFIVM));
                     }
                 }
             }
@@ -390,166 +391,7 @@ namespace Tanzu.Toolkit.ViewModels
 
             foreach (CfInstanceViewModel cfivm in cfsToRemove)
             {
-                CloudFoundryList.Remove(cfivm);
-            }
-        }
-
-        /// <summary>
-        /// Add any avms to svm.Children which are in currentApps but not in svm.Children.
-        /// </summary>
-        /// <param name="svm"></param>
-        /// <param name="currentApps"></param>
-        private static void AddNewApps(SpaceViewModel svm, ObservableCollection<AppViewModel> currentApps)
-        {
-            foreach (AppViewModel newAVM in currentApps)
-            {
-                if (newAVM != null)
-                {
-                    bool appInChildren = svm.Children.Any(avm =>
-                    {
-                        var oldAVM = avm as AppViewModel;
-                        return oldAVM != null && oldAVM.App.AppId == newAVM.App.AppId;
-                    });
-
-                    if (!appInChildren)
-                    {
-                        svm.Children.Add(newAVM);
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Remove all avms from svm.Children which don't appear in currentApps.
-        /// </summary>
-        /// <param name="svm"></param>
-        /// <param name="currentApps"></param>
-        private static void RemoveNonexistentApps(SpaceViewModel svm, ObservableCollection<AppViewModel> currentApps)
-        {
-            var appsToRemove = new ObservableCollection<AppViewModel>();
-
-            foreach (TreeViewItemViewModel priorChild in svm.Children)
-            {
-                if (priorChild is AppViewModel oldAVM)
-                {
-                    bool appStillExists = currentApps.Any(avm => avm != null && avm.App.AppId == oldAVM.App.AppId);
-
-                    if (!appStillExists)
-                    {
-                        appsToRemove.Add(oldAVM);
-                    }
-                }
-            }
-
-            foreach (AppViewModel avm in appsToRemove)
-            {
-                svm.Children.Remove(avm);
-            }
-        }
-
-        /// <summary>
-        /// Add any svms to ovm.Children which are in currentSpaces but not in ovm.Children.
-        /// </summary>
-        /// <param name="ovm"></param>
-        /// <param name="currentSpaces"></param>
-        private static void AddNewSpaces(OrgViewModel ovm, ObservableCollection<SpaceViewModel> currentSpaces)
-        {
-            foreach (SpaceViewModel newSVM in currentSpaces)
-            {
-                if (newSVM != null)
-                {
-                    bool spaceInChildren = ovm.Children.Any(svm =>
-                    {
-                        var oldSVM = svm as SpaceViewModel;
-                        return oldSVM != null && oldSVM.Space.SpaceId == newSVM.Space.SpaceId;
-                    });
-
-                    if (!spaceInChildren)
-                    {
-                        ovm.Children.Add(newSVM);
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Remove all svms from ovm.Children which don't appear in currentSpaces.
-        /// </summary>
-        /// <param name="ovm"></param>
-        /// <param name="currentSpaces"></param>
-        private static void RemoveNonexistentSpaces(OrgViewModel ovm, ObservableCollection<SpaceViewModel> currentSpaces)
-        {
-            var spacesToRemove = new ObservableCollection<SpaceViewModel>();
-
-            foreach (TreeViewItemViewModel priorChild in ovm.Children)
-            {
-                if (priorChild is SpaceViewModel oldSVM)
-                {
-                    bool spaceStillExists = currentSpaces.Any(svm => svm != null && svm.Space.SpaceId == oldSVM.Space.SpaceId);
-
-                    if (!spaceStillExists)
-                    {
-                        spacesToRemove.Add(oldSVM);
-                    }
-                }
-            }
-
-            foreach (SpaceViewModel svm in spacesToRemove)
-            {
-                ovm.Children.Remove(svm);
-            }
-        }
-
-        /// <summary>
-        /// add any ovms to cfivm.Children which are in currentOrgs but not in cfivm.Children.
-        /// </summary>
-        /// <param name="cfivm"></param>
-        /// <param name="currentOrgs"></param>
-        private static void AddNewOrgs(CfInstanceViewModel cfivm, ObservableCollection<OrgViewModel> currentOrgs)
-        {
-            foreach (OrgViewModel newOVM in currentOrgs)
-            {
-                if (newOVM != null)
-                {
-                    bool orgInChildren = cfivm.Children.Any(ovm =>
-                    {
-                        var oldOVM = ovm as OrgViewModel;
-                        return oldOVM != null && oldOVM.Org.OrgId == newOVM.Org.OrgId;
-                    });
-
-                    if (!orgInChildren)
-                    {
-                        cfivm.Children.Add(newOVM);
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// remove all ovms from cfivm.Children which don't appear in currentOrgs.
-        /// </summary>
-        /// <param name="cfivm"></param>
-        /// <param name="currentOrgs"></param>
-        private static void RemoveNonexistentOrgs(CfInstanceViewModel cfivm, ObservableCollection<OrgViewModel> currentOrgs)
-        {
-            var orgsToRemove = new ObservableCollection<OrgViewModel>();
-
-            foreach (TreeViewItemViewModel priorChild in cfivm.Children)
-            {
-                if (priorChild is OrgViewModel oldOVM)
-                {
-                    bool orgStillExists = currentOrgs.Any(ovm => ovm != null && ovm.Org.OrgId == oldOVM.Org.OrgId);
-
-                    if (!orgStillExists)
-                    {
-                        orgsToRemove.Add(oldOVM);
-                    }
-                }
-            }
-
-            foreach (OrgViewModel ovm in orgsToRemove)
-            {
-                cfivm.Children.Remove(ovm);
+                UiDispatcherService.RunOnUiThread(() => CloudFoundryList.Remove(cfivm));
             }
         }
 

--- a/src/ViewModels/src/CloudExplorer/ICloudExplorerViewModel.cs
+++ b/src/ViewModels/src/CloudExplorer/ICloudExplorerViewModel.cs
@@ -5,31 +5,21 @@ namespace Tanzu.Toolkit.ViewModels
     public interface ICloudExplorerViewModel : IViewModel
     {
         bool HasCloudTargets { get; set; }
-
         bool CanOpenLoginView(object arg);
-
         void OpenLoginView(object arg);
-
         bool CanStopCfApp(object arg);
-
-        Task StopCfApp(object arg);
-
         bool CanStartCfApp(object arg);
-
-        Task StartCfApp(object arg);
-
         bool CanDeleteCfApp(object arg);
-
-        Task DeleteCfApp(object arg);
-
-        Task RefreshSpace(object space);
-
         bool CanRefreshSpace(object arg);
-        Task RefreshAllCloudConnections(object arg);
-        bool CanRefreshAllCloudConnections(object arg);
-        void RemoveCloudConnection(object arg);
+        bool CanInitiateFullRefresh(object arg);
         bool CanRemoveCloudConnecion(object arg);
-        Task DisplayRecentAppLogs(object app);
         bool CanDisplayRecentAppLogs(object arg);
+        Task StopCfApp(object arg);
+        Task StartCfApp(object arg);
+        Task DeleteCfApp(object arg);
+        void RefreshSpace(object arg);
+        void RefreshAllItems(object arg);
+        void RemoveCloudConnection(object arg);
+        Task DisplayRecentAppLogs(object app);
     }
 }

--- a/src/ViewModels/src/TreeViewItems/AppViewModel.cs
+++ b/src/ViewModels/src/TreeViewItems/AppViewModel.cs
@@ -27,7 +27,7 @@ namespace Tanzu.Toolkit.ViewModels
             }
         }
 
-        public void SignalIsStoppedChanged()
+        public void RefreshAppState()
         {
             RaisePropertyChangedEvent("IsStopped");
         }

--- a/src/ViewModels/src/TreeViewItems/CfInstanceViewModel.cs
+++ b/src/ViewModels/src/TreeViewItems/CfInstanceViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Tanzu.Toolkit.Models;
 
@@ -14,8 +15,8 @@ namespace Tanzu.Toolkit.ViewModels
 
         public CloudFoundryInstance CloudFoundryInstance { get; }
 
-        public CfInstanceViewModel(CloudFoundryInstance cloudFoundryInstance, IServiceProvider services)
-            : base(null, services)
+        public CfInstanceViewModel(CloudFoundryInstance cloudFoundryInstance, IServiceProvider services, bool expanded = false)
+            : base(null, services, expanded: expanded)
         {
             CloudFoundryInstance = cloudFoundryInstance;
             DisplayText = CloudFoundryInstance.InstanceName;
@@ -95,5 +96,76 @@ namespace Tanzu.Toolkit.ViewModels
                 IsExpanded = false;
             }
         }
+
+        public override async Task RefreshChildren()
+        {
+            var freshOrgs = await FetchChildren();
+
+            RemoveNonexistentOrgs(freshOrgs);
+            AddNewOrgs(freshOrgs);
+
+            if (Children.Count == 0)
+            {
+                UiDispatcherService.RunOnUiThread(() => Children.Add(EmptyPlaceholder));
+            }
+            else if (Children.Count > 1 && HasEmptyPlaceholder)
+            {
+                UiDispatcherService.RunOnUiThread(() => Children.Remove(EmptyPlaceholder));
+            }
+        }
+
+        /// <summary>
+        /// add any ovms to cfivm.Children which are in currentOrgs but not in cfivm.Children.
+        /// </summary>
+        /// <param name="cfivm"></param>
+        /// <param name="freshOrgs"></param>
+        private void AddNewOrgs(ObservableCollection<OrgViewModel> freshOrgs)
+        {
+            foreach (OrgViewModel newOVM in freshOrgs)
+            {
+                if (newOVM != null)
+                {
+                    bool orgInChildren = Children.Any(ovm =>
+                    {
+                        var oldOVM = ovm as OrgViewModel;
+                        return oldOVM != null && oldOVM.Org.OrgId == newOVM.Org.OrgId;
+                    });
+
+                    if (!orgInChildren)
+                    {
+                        UiDispatcherService.RunOnUiThread(() => Children.Add(newOVM));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// remove all ovms from cfivm.Children which don't appear in currentOrgs.
+        /// </summary>
+        /// <param name="cfivm"></param>
+        /// <param name="freshOrgs"></param>
+        private void RemoveNonexistentOrgs(ObservableCollection<OrgViewModel> freshOrgs)
+        {
+            var orgsToRemove = new ObservableCollection<OrgViewModel>();
+
+            foreach (TreeViewItemViewModel priorChild in Children)
+            {
+                if (priorChild is OrgViewModel oldOVM)
+                {
+                    bool orgStillExists = freshOrgs.Any(ovm => ovm != null && ovm.Org.OrgId == oldOVM.Org.OrgId);
+
+                    if (!orgStillExists)
+                    {
+                        orgsToRemove.Add(oldOVM);
+                    }
+                }
+            }
+
+            foreach (OrgViewModel ovm in orgsToRemove)
+            {
+                UiDispatcherService.RunOnUiThread(() => Children.Remove(ovm));
+            }
+        }
+
     }
 }

--- a/src/ViewModels/src/TreeViewItems/ITreeViewItemViewModel.cs
+++ b/src/ViewModels/src/TreeViewItems/ITreeViewItemViewModel.cs
@@ -12,6 +12,7 @@ namespace Tanzu.Toolkit.ViewModels
         TreeViewItemViewModel Parent { get; }
         PlaceholderViewModel LoadingPlaceholder { get; }
         PlaceholderViewModel EmptyPlaceholder { get; }
+
         Task RefreshChildren();
     }
 }

--- a/src/ViewModels/src/TreeViewItems/SpaceViewModel.cs
+++ b/src/ViewModels/src/TreeViewItems/SpaceViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Tanzu.Toolkit.Models;
 
@@ -13,8 +14,8 @@ namespace Tanzu.Toolkit.ViewModels
 
         public CloudFoundrySpace Space { get; }
 
-        public SpaceViewModel(CloudFoundrySpace space, IServiceProvider services)
-            : base(null, services)
+        public SpaceViewModel(CloudFoundrySpace space, IServiceProvider services, bool expanded = false)
+            : base(null, services, expanded: expanded)
         {
             Space = space;
             DisplayText = Space.SpaceName;
@@ -90,6 +91,11 @@ namespace Tanzu.Toolkit.ViewModels
 
                 IsExpanded = false;
             }
+        }
+
+        public override async Task RefreshChildren()
+        {
+            await LoadChildren();
         }
     }
 }

--- a/src/ViewModels/src/TreeViewItems/TreeViewItemViewModel.cs
+++ b/src/ViewModels/src/TreeViewItems/TreeViewItemViewModel.cs
@@ -15,13 +15,13 @@ namespace Tanzu.Toolkit.ViewModels
         private TreeViewItemViewModel _parent;
         private ObservableCollection<TreeViewItemViewModel> _children;
         private bool _isLoading;
-        private IThreadingService _threadingService; 
+        private IThreadingService _threadingService;
 
-        protected TreeViewItemViewModel(TreeViewItemViewModel parent, IServiceProvider services, bool childless = false)
+        protected TreeViewItemViewModel(TreeViewItemViewModel parent, IServiceProvider services, bool childless = false, bool expanded = false)
             : base(services)
         {
             _parent = parent;
-            _isExpanded = false;
+            _isExpanded = expanded;
             _isLoading = false;
 
             _threadingService = services.GetRequiredService<IThreadingService>();
@@ -142,19 +142,21 @@ namespace Tanzu.Toolkit.ViewModels
 
         public virtual PlaceholderViewModel EmptyPlaceholder { get; protected set; }
 
-        public async Task RefreshChildren()
-        {
-            await LoadChildren();
-        }
-
         /// <summary>
         /// Invoked when the child items need to be loaded on demand.
         /// Subclasses can override this to populate the Children collection.
         /// </summary>
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         protected internal virtual async Task LoadChildren()
         {
+            await Task.Run(() => Logger.Error("TreeViewItemViewModel.LoadChildren was called; this method should only ever be run by classes that inherit from TreeViewItemViewModel."));
         }
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        /// <summary>
+        /// Implemented by inheriting classes to update children with fresh data.
+        /// </summary>
+        public virtual async Task RefreshChildren()
+        {
+            await Task.Run(() => Logger.Error("TreeViewItemViewModel.RefreshChildren was called; this method should only ever be run by classes that inherit from TreeViewItemViewModel."));
+        }
     }
 }

--- a/src/ViewModels/test/CfInstanceViewModelTests.cs
+++ b/src/ViewModels/test/CfInstanceViewModelTests.cs
@@ -30,10 +30,10 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             MockUiDispatcherService.Setup(mock => mock.
                 RunOnUiThread(It.IsAny<Action>()))
-                    .Callback<Action>(method =>
+                    .Callback<Action>(action =>
                     {
                         // Run whatever method is passed to MockUiDispatcherService.RunOnUiThread; do not delegate to the UI Dispatcher
-                        method();
+                        action();
                     });
         }
 

--- a/src/ViewModels/test/CfInstanceViewModelTests.cs
+++ b/src/ViewModels/test/CfInstanceViewModelTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -25,6 +27,14 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             {
                 _receivedEvents.Add(e.PropertyName);
             };
+
+            MockUiDispatcherService.Setup(mock => mock.
+                RunOnUiThread(It.IsAny<Action>()))
+                    .Callback<Action>(method =>
+                    {
+                        // Run whatever method is passed to MockUiDispatcherService.RunOnUiThread; do not delegate to the UI Dispatcher
+                        method();
+                    });
         }
 
         [TestCleanup]
@@ -253,6 +263,138 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             MockDialogService.Verify(mock => mock.
               DisplayErrorDialog(CfInstanceViewModel._getOrgsFailureMsg, fakeFailedResult.Explanation),
                 Times.Once);
+        }
+
+        [TestMethod]
+        [TestCategory("RefreshChildren")]
+        public async Task RefreshCfInstance_UpdatesChildrenOnCfInstanceViewModel()
+        {
+            var fakeOrgName1 = "fake org 1";
+            var fakeOrgName2 = "fake org 2";
+            var fakeOrgName3 = "fake org 3";
+            var fakeOrgName4 = "fake org 4";
+
+            var fakeOrgGuid1 = "fake org 1";
+            var fakeOrgGuid2 = "fake org 2";
+            var fakeOrgGuid3 = "fake org 3";
+            var fakeOrgGuid4 = "fake org 4";
+
+            _sut.Children = new ObservableCollection<TreeViewItemViewModel>
+            {
+                // to be removed:
+                new OrgViewModel(new CloudFoundryOrganization(fakeOrgName1, fakeOrgGuid1, _sut.CloudFoundryInstance), Services), 
+                // to stay:
+                new OrgViewModel(new CloudFoundryOrganization(fakeOrgName2, fakeOrgGuid2, _sut.CloudFoundryInstance), Services, expanded: true), // should stay expanded after refresh 
+                new OrgViewModel(new CloudFoundryOrganization(fakeOrgName3, fakeOrgGuid3, _sut.CloudFoundryInstance), Services, expanded: false), // should stay collapsed after refresh 
+            };
+
+            var fakeOrgsList = new List<CloudFoundryOrganization>
+            {
+                // original:
+                new CloudFoundryOrganization(fakeOrgName2, fakeOrgGuid2, _sut.CloudFoundryInstance), 
+                new CloudFoundryOrganization(fakeOrgName3, fakeOrgGuid3, _sut.CloudFoundryInstance),
+                // new:
+                new CloudFoundryOrganization(fakeOrgName4, fakeOrgGuid4, _sut.CloudFoundryInstance),
+            };
+
+            var fakeSuccessResult = new DetailedResult<List<CloudFoundryOrganization>>(succeeded: true, content: fakeOrgsList);
+
+            Assert.AreEqual(3, _sut.Children.Count);
+            OrgViewModel initialChildOrg1 = (OrgViewModel)_sut.Children[0];
+            OrgViewModel initialChildOrg2 = (OrgViewModel)_sut.Children[1];
+            OrgViewModel initialChildOrg3 = (OrgViewModel)_sut.Children[2];
+            Assert.AreEqual(fakeOrgName1, initialChildOrg1.Org.OrgName);
+            Assert.AreEqual(fakeOrgName2, initialChildOrg2.Org.OrgName);
+            Assert.AreEqual(fakeOrgName3, initialChildOrg3.Org.OrgName);
+            Assert.IsFalse(initialChildOrg1.IsExpanded);
+            Assert.IsTrue(initialChildOrg2.IsExpanded);
+            Assert.IsFalse(initialChildOrg3.IsExpanded);
+
+            MockCloudFoundryService.Setup(mock => mock.
+                GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true))
+                    .ReturnsAsync(fakeSuccessResult);
+
+            _receivedEvents.Clear();
+
+            await _sut.RefreshChildren();
+
+            Assert.AreEqual(3, _sut.Children.Count);
+            OrgViewModel refreshedChildOrg1 = (OrgViewModel)_sut.Children[0];
+            OrgViewModel refreshedChildOrg2 = (OrgViewModel)_sut.Children[1];
+            OrgViewModel refreshedChildOrg3 = (OrgViewModel)_sut.Children[2];
+            Assert.AreEqual(fakeOrgName2, refreshedChildOrg1.Org.OrgName);
+            Assert.AreEqual(fakeOrgName3, refreshedChildOrg2.Org.OrgName);
+            Assert.AreEqual(fakeOrgName4, refreshedChildOrg3.Org.OrgName);
+            Assert.IsTrue(refreshedChildOrg1.IsExpanded); // children that aren't new shouldn't change expansion
+            Assert.IsFalse(refreshedChildOrg2.IsExpanded); // children that aren't new shouldn't change expansion
+            Assert.IsFalse(refreshedChildOrg2.IsExpanded); // new children should start collapsed
+
+            // property changed events should not be raised
+            Assert.AreEqual(0, _receivedEvents.Count);
+
+            MockCloudFoundryService.VerifyAll();
+        }
+
+        [TestMethod]
+        [TestCategory("RefreshChildren")]
+        public async Task RefreshChildren_AddsPlaceholder_WhenAllOrgsAreRemoved()
+        {
+            var fakeInitialOrg = new CloudFoundryOrganization("fake org name", "fake org id", parentCf: _sut.CloudFoundryInstance);
+            var ovm = new OrgViewModel(fakeInitialOrg, Services);
+
+            var fakeEmptyOrgsResult = new DetailedResult<List<CloudFoundryOrganization>>(
+                succeeded: true,
+                content: new List<CloudFoundryOrganization>(), // simulate cf having lost all orgs before refresh
+                explanation: null,
+                cmdDetails: FakeSuccessCmdResult);
+
+            MockCloudFoundryService.Setup(mock => mock.
+                GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true))
+                    .ReturnsAsync(fakeEmptyOrgsResult);
+
+            _sut.Children = new ObservableCollection<TreeViewItemViewModel> { ovm }; // simulate cf initially having 1 org child
+
+            Assert.AreEqual(1, _sut.Children.Count);
+            Assert.AreEqual(typeof(OrgViewModel), _sut.Children[0].GetType());
+
+            await _sut.RefreshChildren();
+
+            Assert.AreEqual(1, _sut.Children.Count);
+            Assert.AreEqual(typeof(PlaceholderViewModel), _sut.Children[0].GetType());
+            Assert.AreEqual(CfInstanceViewModel._emptyOrgsPlaceholderMsg, _sut.Children[0].DisplayText);
+        }
+
+        [TestMethod]
+        [TestCategory("RefreshChildren")]
+        public async Task RefreshChildren_RemovesPlaceholder_WhenEmptyCfGainsChildren()
+        {
+            // simulate cf initially having no org children
+            _sut.Children = new ObservableCollection<TreeViewItemViewModel> { _sut.EmptyPlaceholder };
+            _sut.HasEmptyPlaceholder = true;
+
+            var fakeNewOrg = new CloudFoundryOrganization("fake org name", "fake org id", _sut.CloudFoundryInstance);
+
+            var fakeSuccessfulOrgsResult = new DetailedResult<List<CloudFoundryOrganization>>(
+                succeeded: true,
+                content: new List<CloudFoundryOrganization>
+                {
+                    fakeNewOrg, // simulate cf having gained an org child before refresh
+                },
+                explanation: null,
+                cmdDetails: FakeSuccessCmdResult);
+
+            MockCloudFoundryService.Setup(mock => mock.
+                GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true))
+                    .ReturnsAsync(fakeSuccessfulOrgsResult);
+
+            Assert.AreEqual(1, _sut.Children.Count);
+            Assert.AreEqual(typeof(PlaceholderViewModel), _sut.Children[0].GetType());
+            Assert.AreEqual(CfInstanceViewModel._emptyOrgsPlaceholderMsg, _sut.Children[0].DisplayText);
+
+            await _sut.RefreshChildren();
+
+            Assert.AreEqual(1, _sut.Children.Count);
+            Assert.AreEqual(typeof(OrgViewModel), _sut.Children[0].GetType());
         }
     }
 }

--- a/src/ViewModels/test/CloudExplorerViewModelTests.cs
+++ b/src/ViewModels/test/CloudExplorerViewModelTests.cs
@@ -26,9 +26,9 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             // to RunOnUiThread; do not delegate to the UI Dispatcher
             MockUiDispatcherService.Setup(mock => mock.
                 RunOnUiThread(It.IsAny<Action>()))
-                    .Callback<Action>(method =>
+                    .Callback<Action>(action =>
                     {
-                        method();
+                        action();
                     });
 
             // set up mock threading service to run whatever method is passed

--- a/src/ViewModels/test/OrgViewModelTests.cs
+++ b/src/ViewModels/test/OrgViewModelTests.cs
@@ -31,10 +31,10 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             MockUiDispatcherService.Setup(mock => mock.
                 RunOnUiThread(It.IsAny<Action>()))
-                    .Callback<Action>(method =>
+                    .Callback<Action>(action =>
                     {
                         // Run whatever method is passed to MockUiDispatcherService.RunOnUiThread; do not delegate to the UI Dispatcher
-                        method();
+                        action();
                     });
         }
 

--- a/src/ViewModels/test/OrgViewModelTests.cs
+++ b/src/ViewModels/test/OrgViewModelTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -26,6 +28,14 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             {
                 _receivedEvents.Add(e.PropertyName);
             };
+
+            MockUiDispatcherService.Setup(mock => mock.
+                RunOnUiThread(It.IsAny<Action>()))
+                    .Callback<Action>(method =>
+                    {
+                        // Run whatever method is passed to MockUiDispatcherService.RunOnUiThread; do not delegate to the UI Dispatcher
+                        method();
+                    });
         }
 
         [TestCleanup]
@@ -218,5 +228,140 @@ namespace Tanzu.Toolkit.ViewModels.Tests
               DisplayErrorDialog(OrgViewModel._getSpacesFailureMsg, fakeFailedResult.Explanation),
                 Times.Once);
         }
+        
+        [TestMethod]
+        [TestCategory("RefreshChildren")]
+        public async Task RefreshOrg_UpdatesChildrenOnOrgViewModel()
+        {
+            var fakeSpaceName1 = "fake space 1";
+            var fakeSpaceName2 = "fake space 2";
+            var fakeSpaceName3 = "fake space 3";
+            var fakeSpaceName4 = "fake space 4";
+
+            var fakeSpaceGuid1 = "fake space 1";
+            var fakeSpaceGuid2 = "fake space 2";
+            var fakeSpaceGuid3 = "fake space 3";
+            var fakeSpaceGuid4 = "fake space 4";
+
+            _sut.Children = new ObservableCollection<TreeViewItemViewModel>
+            {
+                // to be removed:
+                new SpaceViewModel(new CloudFoundrySpace(fakeSpaceName1, fakeSpaceGuid1, _sut.Org), Services), 
+                // to stay:
+                new SpaceViewModel(new CloudFoundrySpace(fakeSpaceName2, fakeSpaceGuid2, _sut.Org), Services, expanded: true), // should stay expanded after refresh 
+                new SpaceViewModel(new CloudFoundrySpace(fakeSpaceName3, fakeSpaceGuid3, _sut.Org), Services, expanded: false), // should stay collapsed after refresh 
+            };
+
+            var fakeSpacesList = new List<CloudFoundrySpace>
+            {
+                // original:
+                new CloudFoundrySpace(fakeSpaceName2, fakeSpaceGuid2, _sut.Org),
+                new CloudFoundrySpace(fakeSpaceName3, fakeSpaceGuid3, _sut.Org),
+                // new:
+                new CloudFoundrySpace(fakeSpaceName4, fakeSpaceGuid4, _sut.Org),
+            };
+
+            var fakeSuccessResult = new DetailedResult<List<CloudFoundrySpace>>(succeeded: true, content: fakeSpacesList);
+
+            Assert.AreEqual(3, _sut.Children.Count);
+            SpaceViewModel initialChildSpace1 = (SpaceViewModel)_sut.Children[0];
+            SpaceViewModel initialChildSpace2 = (SpaceViewModel)_sut.Children[1];
+            SpaceViewModel initialChildSpace3 = (SpaceViewModel)_sut.Children[2];
+            Assert.AreEqual(fakeSpaceName1, initialChildSpace1.Space.SpaceName);
+            Assert.AreEqual(fakeSpaceName2, initialChildSpace2.Space.SpaceName);
+            Assert.AreEqual(fakeSpaceName3, initialChildSpace3.Space.SpaceName);
+            Assert.IsFalse(initialChildSpace1.IsExpanded);
+            Assert.IsTrue(initialChildSpace2.IsExpanded);
+            Assert.IsFalse(initialChildSpace3.IsExpanded);
+
+            MockCloudFoundryService.Setup(mock => mock.
+                GetSpacesForOrgAsync(_sut.Org, true))
+                    .ReturnsAsync(fakeSuccessResult);
+
+            _receivedEvents.Clear();
+
+            await _sut.RefreshChildren();
+
+            Assert.AreEqual(3, _sut.Children.Count);
+            SpaceViewModel refreshedChildSpace1 = (SpaceViewModel)_sut.Children[0];
+            SpaceViewModel refreshedChildSpace2 = (SpaceViewModel)_sut.Children[1];
+            SpaceViewModel refreshedChildSpace3 = (SpaceViewModel)_sut.Children[2];
+            Assert.AreEqual(fakeSpaceName2, refreshedChildSpace1.Space.SpaceName);
+            Assert.AreEqual(fakeSpaceName3, refreshedChildSpace2.Space.SpaceName);
+            Assert.AreEqual(fakeSpaceName4, refreshedChildSpace3.Space.SpaceName);
+            Assert.IsTrue(refreshedChildSpace1.IsExpanded); // children that aren't new shouldn't change expansion
+            Assert.IsFalse(refreshedChildSpace2.IsExpanded); // children that aren't new shouldn't change expansion
+            Assert.IsFalse(refreshedChildSpace2.IsExpanded); // new children should start collapsed
+
+            // property changed events should not be raised
+            Assert.AreEqual(0, _receivedEvents.Count);
+
+            MockCloudFoundryService.VerifyAll();
+        }
+
+        [TestMethod]
+        [TestCategory("RefreshChildren")]
+        public async Task RefreshChildren_AddsPlaceholder_WhenAllSpacesAreRemoved()
+        {
+            var fakeInitialSpace = new CloudFoundrySpace("fake space name", "fake space id", _sut.Org);
+            var svm = new SpaceViewModel(fakeInitialSpace, Services);
+
+            var fakeNoSpacesResult = new DetailedResult<List<CloudFoundrySpace>>(
+                succeeded: true,
+                content: new List<CloudFoundrySpace>(), // simulate org having lost all spaces before refresh
+                explanation: null,
+                cmdDetails: FakeSuccessCmdResult);
+
+            MockCloudFoundryService.Setup(mock => mock.
+                GetSpacesForOrgAsync(_sut.Org, true))
+                    .ReturnsAsync(fakeNoSpacesResult);
+
+            _sut.Children = new ObservableCollection<TreeViewItemViewModel> { svm }; // simulate org initially having 1 space child
+
+            Assert.AreEqual(1, _sut.Children.Count);
+            Assert.AreEqual(typeof(SpaceViewModel), _sut.Children[0].GetType());
+
+            await _sut.RefreshChildren();
+
+            Assert.AreEqual(1, _sut.Children.Count);
+            Assert.AreEqual(typeof(PlaceholderViewModel), _sut.Children[0].GetType());
+            Assert.AreEqual(OrgViewModel._emptySpacesPlaceholderMsg, _sut.Children[0].DisplayText);
+        }
+
+        [TestMethod]
+        [TestCategory("RefreshChildren")]
+        public async Task RefreshChildren_RemovesPlaceholder_WhenEmptyOrgGainsChildren()
+        {
+            // simulate org initially having no space children
+            _sut.Children = new ObservableCollection<TreeViewItemViewModel> { _sut.EmptyPlaceholder };
+            _sut.HasEmptyPlaceholder = true;
+
+            var fakeNewSpace = new CloudFoundrySpace("fake space name", "fake space id", _sut.Org);
+
+            var fakeSuccessfulSpacesResult = new DetailedResult<List<CloudFoundrySpace>>(
+                succeeded: true,
+                content: new List<CloudFoundrySpace>
+                {
+                    fakeNewSpace, // simulate org having gained a space child before refresh
+                },
+                explanation: null,
+                cmdDetails: FakeSuccessCmdResult);
+
+            MockCloudFoundryService.Setup(mock => mock.
+                GetSpacesForOrgAsync(_sut.Org, true))
+                    .ReturnsAsync(fakeSuccessfulSpacesResult);
+
+            _sut.Children = new ObservableCollection<TreeViewItemViewModel> { _sut.EmptyPlaceholder }; // simulate org initially having no space children
+
+            Assert.AreEqual(1, _sut.Children.Count);
+            Assert.AreEqual(typeof(PlaceholderViewModel), _sut.Children[0].GetType());
+            Assert.AreEqual(OrgViewModel._emptySpacesPlaceholderMsg, _sut.Children[0].DisplayText);
+
+            await _sut.RefreshChildren();
+
+            Assert.AreEqual(1, _sut.Children.Count);
+            Assert.AreEqual(typeof(SpaceViewModel), _sut.Children[0].GetType());
+        }
+
     }
 }

--- a/src/ViewModels/test/SpaceViewModelTests.cs
+++ b/src/ViewModels/test/SpaceViewModelTests.cs
@@ -31,10 +31,10 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             MockUiDispatcherService.Setup(mock => mock.
                 RunOnUiThread(It.IsAny<Action>()))
-                    .Callback<Action>(method =>
+                    .Callback<Action>(action =>
                     {
                         // Run whatever method is passed to MockUiDispatcherService.RunOnUiThread; do not delegate to the UI Dispatcher
-                        method();
+                        action();
                     });
         }
 

--- a/src/ViewModels/test/SpaceViewModelTests.cs
+++ b/src/ViewModels/test/SpaceViewModelTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -26,6 +28,14 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             {
                 _receivedEvents.Add(e.PropertyName);
             };
+
+            MockUiDispatcherService.Setup(mock => mock.
+                RunOnUiThread(It.IsAny<Action>()))
+                    .Callback<Action>(method =>
+                    {
+                        // Run whatever method is passed to MockUiDispatcherService.RunOnUiThread; do not delegate to the UI Dispatcher
+                        method();
+                    });
         }
 
         [TestCleanup]
@@ -217,6 +227,189 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             MockDialogService.Verify(mock => mock.
               DisplayErrorDialog(SpaceViewModel._getAppsFailureMsg, fakeFailedResult.Explanation),
                 Times.Once);
+        }
+
+        [TestMethod]
+        [TestCategory("RefreshChildren")]
+        public async Task RefreshSpace_UpdatesChildrenOnSpaceViewModel()
+        {
+            var fakeAppName1 = "fake app 1";
+            var fakeAppName2 = "fake app 2";
+            var fakeAppName3 = "fake app 3";
+            var fakeAppName4 = "fake app 4";
+
+            var fakeAppGuid1 = "fake app 1";
+            var fakeAppGuid2 = "fake app 2";
+            var fakeAppGuid3 = "fake app 3";
+            var fakeAppGuid4 = "fake app 4";
+
+            var initialState1 = "junk";
+            var initialState2 = "asdf";
+            var initialState3 = "xkcd";
+
+            _sut.Children = new ObservableCollection<TreeViewItemViewModel>
+            {
+                // to be removed:
+                new AppViewModel(new CloudFoundryApp(fakeAppName1, fakeAppGuid1, _sut.Space, initialState1), Services), 
+                // to stay:
+                new AppViewModel(new CloudFoundryApp(fakeAppName2, fakeAppGuid2, _sut.Space, state: initialState2), Services), // should keep state after refresh 
+                new AppViewModel(new CloudFoundryApp(fakeAppName3, fakeAppGuid3, _sut.Space, state: initialState3), Services), // should change state after refresh 
+            };
+
+            var fakeAppsList = new List<CloudFoundryApp>
+            {
+                // original:
+                new CloudFoundryApp(fakeAppName2, fakeAppGuid2, _sut.Space, initialState2),
+                new CloudFoundryApp(fakeAppName3, fakeAppGuid3, _sut.Space, "new state"),
+                // new:
+                new CloudFoundryApp(fakeAppName4, fakeAppGuid4, _sut.Space, "new app, new state"),
+            };
+
+            var fakeSuccessResult = new DetailedResult<List<CloudFoundryApp>>(succeeded: true, content: fakeAppsList);
+
+            Assert.AreEqual(3, _sut.Children.Count);
+            AppViewModel initialChildApp1 = (AppViewModel)_sut.Children[0];
+            AppViewModel initialChildApp2 = (AppViewModel)_sut.Children[1];
+            AppViewModel initialChildApp3 = (AppViewModel)_sut.Children[2];
+            Assert.AreEqual(fakeAppName1, initialChildApp1.App.AppName);
+            Assert.AreEqual(fakeAppName2, initialChildApp2.App.AppName);
+            Assert.AreEqual(fakeAppName3, initialChildApp3.App.AppName);
+            Assert.AreEqual(initialState2, initialChildApp2.App.State);
+            Assert.AreEqual(initialState3, initialChildApp3.App.State);
+
+            MockCloudFoundryService.Setup(mock => mock.
+                GetAppsForSpaceAsync(_sut.Space, true))
+                    .ReturnsAsync(fakeSuccessResult);
+
+            _receivedEvents.Clear();
+
+            await _sut.RefreshChildren();
+
+            Assert.AreEqual(3, _sut.Children.Count);
+            AppViewModel refreshedChildApp1 = (AppViewModel)_sut.Children[0];
+            AppViewModel refreshedChildApp2 = (AppViewModel)_sut.Children[1];
+            AppViewModel refreshedChildApp3 = (AppViewModel)_sut.Children[2];
+            Assert.AreEqual(fakeAppName2, refreshedChildApp1.App.AppName);
+            Assert.AreEqual(fakeAppName3, refreshedChildApp2.App.AppName);
+            Assert.AreEqual(fakeAppName4, refreshedChildApp3.App.AppName);
+            Assert.AreEqual(initialState2, refreshedChildApp1.App.State); // previous state shouldn't have changed
+            Assert.AreNotEqual(initialState3, refreshedChildApp2.App.State); // previous state should have changed
+
+            // property changed event should be raised for Children (update UI)
+            Assert.AreEqual(1, _receivedEvents.Count);
+            Assert.AreEqual("Children", _receivedEvents[0]);
+
+            MockCloudFoundryService.VerifyAll();
+        }
+
+        [TestMethod]
+        [TestCategory("RefreshChildren")]
+        public async Task RefreshChildren_AddsPlaceholder_WhenAllAppsAreRemoved()
+        {
+            var fakeInitialApp = new CloudFoundryApp("fake app name", "fake app id", _sut.Space, null);
+            var avm = new AppViewModel(fakeInitialApp, Services);
+
+            var fakeNoAppsResult = new DetailedResult<List<CloudFoundryApp>>(
+                succeeded: true,
+                content: new List<CloudFoundryApp>(), // simulate space having lost all apps before refresh
+                explanation: null,
+                cmdDetails: FakeSuccessCmdResult);
+
+            MockCloudFoundryService.Setup(mock => mock.
+                GetAppsForSpaceAsync(_sut.Space, true))
+                    .ReturnsAsync(fakeNoAppsResult);
+
+            _sut.Children = new ObservableCollection<TreeViewItemViewModel> { avm }; // simulate space initially having 1 app child
+
+            Assert.AreEqual(1, _sut.Children.Count);
+            Assert.AreEqual(typeof(AppViewModel), _sut.Children[0].GetType());
+
+            await _sut.RefreshChildren();
+
+            Assert.AreEqual(1, _sut.Children.Count);
+            Assert.AreEqual(typeof(PlaceholderViewModel), _sut.Children[0].GetType());
+            Assert.AreEqual(SpaceViewModel.EmptyAppsPlaceholderMsg, _sut.Children[0].DisplayText);
+        }
+
+        [TestMethod]
+        [TestCategory("RefreshChildren")]
+        public async Task RefreshChildren_RemovesPlaceholder_WhenEmptySpaceGainsChildren()
+        {
+            // simulate space initially having no app children
+            _sut.Children = new ObservableCollection<TreeViewItemViewModel> { _sut.EmptyPlaceholder };
+            _sut.HasEmptyPlaceholder = true;
+
+            var fakeNewApp = new CloudFoundryApp("fake app name", "fake app id", _sut.Space, null);
+            var avm = new AppViewModel(fakeNewApp, Services);
+
+            var fakeSuccessfulAppsResult = new DetailedResult<List<CloudFoundryApp>>(
+                succeeded: true,
+                content: new List<CloudFoundryApp>
+                {
+                    fakeNewApp, // simulate space having gained an app child before refresh
+                },
+                explanation: null,
+                cmdDetails: FakeSuccessCmdResult);
+
+            MockCloudFoundryService.Setup(mock => mock.
+                GetAppsForSpaceAsync(_sut.Space, true))
+                    .ReturnsAsync(fakeSuccessfulAppsResult);
+
+            _sut.Children = new ObservableCollection<TreeViewItemViewModel> { _sut.EmptyPlaceholder }; // simulate space initially having no app children
+
+            Assert.AreEqual(1, _sut.Children.Count);
+            Assert.AreEqual(typeof(PlaceholderViewModel), _sut.Children[0].GetType());
+            Assert.AreEqual(SpaceViewModel.EmptyAppsPlaceholderMsg, _sut.Children[0].DisplayText);
+
+            await _sut.RefreshChildren();
+
+            Assert.AreEqual(1, _sut.Children.Count);
+            Assert.AreEqual(typeof(AppViewModel), _sut.Children[0].GetType());
+        }
+
+        [TestMethod]
+        [TestCategory("RefreshChildren")]
+        public async Task RefreshChildren_UpdatesAppState_ForAllChildren()
+        {
+            var initialState1 = "INITIAL_FAKE_STATE";
+            var initialState2 = "INITIAL_JUNK_STATE";
+            var initialState3 = "INITIAL_BOGUS_STATE";
+
+            var fakeInitialApp1 = new CloudFoundryApp("fakeApp1", "junk", _sut.Space, initialState1);
+            var fakeInitialApp2 = new CloudFoundryApp("fakeApp2", "junk", _sut.Space, initialState2);
+            var fakeInitialApp3 = new CloudFoundryApp("fakeApp3", "junk", _sut.Space, initialState3);
+
+            var fakeFreshApp1 = new CloudFoundryApp("fakeApp1", "junk", _sut.Space, initialState1);
+            var fakeFreshApp2 = new CloudFoundryApp("fakeApp2", "junk", _sut.Space, "NEW_FRESH_STATE"); // simulate state change
+            var fakeFreshApp3 = new CloudFoundryApp("fakeApp3", "junk", _sut.Space, "NEW_COOL_STATE"); // simulate state change
+
+            _sut.Children = new ObservableCollection<TreeViewItemViewModel>
+            {
+                new AppViewModel(fakeInitialApp1, Services),
+                new AppViewModel(fakeInitialApp2, Services),
+                new AppViewModel(fakeInitialApp3, Services),
+            };
+
+            var fakeSuccessfulAppsResult = new DetailedResult<List<CloudFoundryApp>>(
+                succeeded: true,
+                content: new List<CloudFoundryApp>
+                {
+                    fakeFreshApp1,
+                    fakeFreshApp2,
+                    fakeFreshApp3,
+                },
+                explanation: null,
+                cmdDetails: FakeSuccessCmdResult);
+
+            MockCloudFoundryService.Setup(mock => mock.
+                GetAppsForSpaceAsync(_sut.Space, true))
+                    .ReturnsAsync(fakeSuccessfulAppsResult);
+
+            await _sut.RefreshChildren();
+
+            Assert.AreEqual(fakeInitialApp1.State, fakeFreshApp1.State);
+            Assert.AreNotEqual(fakeInitialApp2.State, fakeFreshApp2.State);
+            Assert.AreNotEqual(fakeInitialApp3.State, fakeFreshApp3.State);
         }
     }
 }

--- a/src/ViewModels/test/ViewModelTestSupport.cs
+++ b/src/ViewModels/test/ViewModelTestSupport.cs
@@ -24,6 +24,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         protected Mock<ILoggingService> MockLoggingService { get; set; }
         protected Mock<ILogger> MockLogger { get; set; }
         protected Mock<IThreadingService> MockThreadingService { get; set; }
+        protected Mock<IUiDispatcherService> MockUiDispatcherService { get; set; }
 
         protected const string FakeCfName = "fake cf name";
         protected const string FakeCfApiAddress = "http://fake.api.address";
@@ -61,6 +62,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             MockViewLocatorService = new Mock<IViewLocatorService>();
             MockLoggingService = new Mock<ILoggingService>();
             MockThreadingService = new Mock<IThreadingService>();
+            MockUiDispatcherService = new Mock<IUiDispatcherService>();
 
             MockLogger = new Mock<ILogger>();
             MockLoggingService.SetupGet(m => m.Logger).Returns(MockLogger.Object);
@@ -70,6 +72,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             services.AddSingleton(MockViewLocatorService.Object);
             services.AddSingleton(MockLoggingService.Object);
             services.AddSingleton(MockThreadingService.Object);
+            services.AddSingleton(MockUiDispatcherService.Object);
 
             Services = services.BuildServiceProvider();
         }

--- a/src/VisualStudioExtension/src/TanzuToolkitForVisualStudioPackage.cs
+++ b/src/VisualStudioExtension/src/TanzuToolkitForVisualStudioPackage.cs
@@ -8,6 +8,7 @@ using EnvDTE80;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.Shell;
 using Tanzu.Toolkit.CloudFoundryApiClient;
+using Tanzu.Toolkit.Services;
 using Tanzu.Toolkit.Services.CfCli;
 using Tanzu.Toolkit.Services.CloudFoundry;
 using Tanzu.Toolkit.Services.CmdProcess;
@@ -18,6 +19,7 @@ using Tanzu.Toolkit.Services.Threading;
 using Tanzu.Toolkit.Services.ViewLocator;
 using Tanzu.Toolkit.ViewModels;
 using Tanzu.Toolkit.VisualStudio.Commands;
+using Tanzu.Toolkit.VisualStudio.WpfViews.Services;
 using Tanzu.Toolkit.WpfViews;
 using Tanzu.Toolkit.WpfViews.Services;
 using Task = System.Threading.Tasks.Task;
@@ -123,6 +125,7 @@ namespace Tanzu.Toolkit.VisualStudio
             services.AddSingleton<ILoggingService, LoggingService>();
             services.AddSingleton<IViewService, VsToolWindowService>();
             services.AddSingleton<IThreadingService, ThreadingService>();
+            services.AddSingleton<IUiDispatcherService, UiDispatcherService>();
 
             services.AddTransient<ICmdProcessService, CmdProcessService>();
 

--- a/src/WpfViews/src/CloudExplorerView.xaml
+++ b/src/WpfViews/src/CloudExplorerView.xaml
@@ -53,8 +53,12 @@
                    ToolTip="Refresh All Cloud Connections"/>
         </Button>
 
-        <Rectangle Grid.Row="1" Grid.ColumnSpan="3" Fill="White"/>
-        
+        <TextBlock Grid.Row="0" Grid.Column="2"
+                   Visibility="{Binding Path=IsRefreshingAll, Converter={StaticResource Visibility}}" 
+                   Text="Refreshing..."/>
+
+        <Rectangle Grid.Row="1" Grid.RowSpan="1" Grid.ColumnSpan="3" Fill="White"/>
+
         <TextBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" 
                  Margin="5"  IsReadOnly="True" 
                  TextWrapping="Wrap" BorderBrush="Transparent" 

--- a/src/WpfViews/src/CloudExplorerView.xaml.cs
+++ b/src/WpfViews/src/CloudExplorerView.xaml.cs
@@ -31,8 +31,8 @@ namespace Tanzu.Toolkit.WpfViews
             StartCfAppCommand = new AsyncDelegatingCommand(viewModel.StartCfApp, viewModel.CanStartCfApp);
             DeleteCfAppCommand = new AsyncDelegatingCommand(viewModel.DeleteCfApp, viewModel.CanDeleteCfApp);
             DisplayRecentAppLogsCommand = new AsyncDelegatingCommand(viewModel.DisplayRecentAppLogs, viewModel.CanDisplayRecentAppLogs);
-            RefreshSpaceCommand = new AsyncDelegatingCommand(viewModel.RefreshSpace, viewModel.CanRefreshSpace);
-            RefreshAllCommand = new AsyncDelegatingCommand(viewModel.RefreshAllCloudConnections, viewModel.CanRefreshAllCloudConnections);
+            RefreshSpaceCommand = new DelegatingCommand(viewModel.RefreshSpace, viewModel.CanRefreshSpace);
+            RefreshAllCommand = new DelegatingCommand(viewModel.RefreshAllItems, viewModel.CanInitiateFullRefresh);
             RemoveCloudConnectionCommand = new DelegatingCommand(viewModel.RemoveCloudConnection, viewModel.CanRemoveCloudConnecion);
 
             DataContext = viewModel;

--- a/src/WpfViews/src/Services/UiDispatcherService.cs
+++ b/src/WpfViews/src/Services/UiDispatcherService.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Windows;
+using Tanzu.Toolkit.Services;
+
+namespace Tanzu.Toolkit.VisualStudio.WpfViews.Services
+{
+    public class UiDispatcherService : IUiDispatcherService
+    {
+        public void RunOnUiThread(Action method)
+        {
+            Application.Current.Dispatcher.Invoke(method);
+        }
+    }
+}

--- a/src/WpfViews/src/Tanzu.Toolkit.WpfViews.csproj
+++ b/src/WpfViews/src/Tanzu.Toolkit.WpfViews.csproj
@@ -76,6 +76,7 @@
       <DependentUpon>OutputView.xaml</DependentUpon>
     </Compile>
     <Compile Include="IViewService.cs" />
+    <Compile Include="Services\UiDispatcherService.cs" />
     <Compile Include="Services\WpfDialogResult.cs" />
     <Compile Include="Services\WpfDialogService.cs" />
     <Compile Include="Services\WpfViewLocatorService.cs" />

--- a/src/WpfViews/test/ViewTestSupport.cs
+++ b/src/WpfViews/test/ViewTestSupport.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using Tanzu.Toolkit.Services;
 using Tanzu.Toolkit.Services.CloudFoundry;
 using Tanzu.Toolkit.Services.Dialog;
 using Tanzu.Toolkit.Services.Logging;
+using Tanzu.Toolkit.Services.Threading;
 using Tanzu.Toolkit.Services.ViewLocator;
 
 namespace Tanzu.Toolkit.WpfViews.Tests
@@ -16,6 +18,8 @@ namespace Tanzu.Toolkit.WpfViews.Tests
         protected Mock<IDialogService> mockDialogService;
         protected Mock<IViewLocatorService> mockViewLocatorService;
         protected Mock<ILoggingService> mockLoggingService;
+        protected Mock<IUiDispatcherService> mockUiDispatcherService;
+        protected Mock<IThreadingService> mockThreadingService;
 
         protected ViewTestSupport()
         {
@@ -24,11 +28,15 @@ namespace Tanzu.Toolkit.WpfViews.Tests
             mockDialogService = new Mock<IDialogService>();
             mockViewLocatorService = new Mock<IViewLocatorService>();
             mockLoggingService = new Mock<ILoggingService>();
+            mockUiDispatcherService = new Mock<IUiDispatcherService>();
+            mockThreadingService = new Mock<IThreadingService>();
 
             services.AddSingleton(mockCloudFoundryService.Object);
             services.AddSingleton(mockDialogService.Object);
             services.AddSingleton(mockViewLocatorService.Object);
             services.AddSingleton(mockLoggingService.Object);
+            services.AddSingleton(mockUiDispatcherService.Object);
+            services.AddSingleton(mockThreadingService.Object);
             this.services = services.BuildServiceProvider();
         }
     }


### PR DESCRIPTION
- add "Refreshing..." text indicator
- parallelize all refresh tasks
- start refresh tasks using ThreadingService (for mockability in
  unit tests).
- fetch fresh cf info in background threads, update tree view items
  on UI thread.
- moved Refresh methods from CloudExplorerViewModel into each
  specific ViewModel.
- split refresh-all method on CloudExplorerViewModel into an internal
  async task ("InitiateFullRefresh") and a synchronous caller method
  ("RefreshAllItems") which just invokes
  threadingService.StartTask(InitiateFullRefresh), allowing unit tests
  to await the internal task while the real implementation does not.
- added `expanded` ctor param to TreeViewItemViewModels
- improve unit tests for each TreeViewItemViewModel's specific
  "refresh" method; ensure that expansion doesn't change in the case
  of cfs/orgs/spaces + ensure all states update for apps.
- ensure RefreshAllItems method only invokes underlying task if
  IsRefreshingAll property is false.