### PR TITLE
Lock & cache access token; re-request after expiration

### DIFF
--- a/src/Services/src/CfCli/CfCliService.cs
+++ b/src/Services/src/CfCli/CfCliService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security;
 using System.Text.Json;
@@ -47,6 +48,10 @@ namespace Tanzu.Toolkit.Services.CfCli
         private readonly IFileLocatorService _fileLocatorService;
         private readonly ILogger _logger;
 
+        private object _tokenLock = new object();
+        private volatile string _cachedAccessToken = null;
+        private DateTime _accessTokenExpiration = new DateTime(0);
+
         public CfCliService(IServiceProvider services)
         {
             Services = services;
@@ -90,15 +95,42 @@ namespace Tanzu.Toolkit.Services.CfCli
 
         public string GetOAuthToken()
         {
-            DetailedResult result = ExecuteCfCliCommand(_getOAuthTokenCmd);
-
-            if (result.CmdDetails.ExitCode != 0)
+            if (_cachedAccessToken == null || _accessTokenExpiration == null || DateTime.Compare(DateTime.Now, _accessTokenExpiration) >= 0)
             {
-                _logger.Error($"GetOAuthToken failed: {result}");
-                return null;
+                lock (_tokenLock)
+                {
+                    try
+                    {
+                        DetailedResult result = ExecuteCfCliCommand(_getOAuthTokenCmd);
+
+                        if (result == null)
+                        {
+                            return null;
+                        }
+
+                        if (result.CmdDetails.ExitCode != 0)
+                        {
+                            _logger.Error($"GetOAuthToken failed: {result}");
+                            return null;
+                        }
+
+                        var accessToken = FormatToken(result.CmdDetails.StdOut);
+
+                        var handler = new JwtSecurityTokenHandler();
+                        var jsonToken = handler.ReadToken(accessToken);
+                        var token = jsonToken as JwtSecurityToken;
+
+                        _cachedAccessToken = accessToken;
+                        _accessTokenExpiration = token.ValidTo;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Error($"Something went wrong while attempting to renew access token {ex.ToString()}");
+                    }
+                }
             }
 
-            return FormatToken(result.CmdDetails.StdOut);
+            return _cachedAccessToken;
         }
 
         public DetailedResult TargetApi(string apiAddress, bool skipSsl)

--- a/src/Services/src/Tanzu.Toolkit.Services.csproj
+++ b/src/Services/src/Tanzu.Toolkit.Services.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Services/test/CfCli/CfCliServiceTestSupport.cs
+++ b/src/Services/test/CfCli/CfCliServiceTestSupport.cs
@@ -24,5 +24,33 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
         internal static readonly string _fakeApps401Output = File.ReadAllText("CfCli/GetV2Apps401Output.txt");
 
         internal static readonly int _numOrgsInFakeResponse = 54;
+
+        /** this fake JWT was created using these values:
+         * HEADER:
+         * {
+         * "typ": "JWT",
+         * "alg": "HS256"
+         * }
+         * 
+         * PAYLOAD:
+         * {
+         * "iss": "junk",
+         * "iat": 1623163938,
+         * "exp": 253370818338,
+         * "aud": "www.example.com",
+         * "sub": "jrocket@example.com",
+         * "GivenName": "Johnny",
+         * "Surname": "Rocket",
+         * "Email": "jrocket@example.com",
+         * "Role": [
+         * "Manager",
+         * "Project Administrator"
+         * ]
+         * }
+         * 
+         * SIGNING KEY:
+         * "qwertyuiopasdfghjklzxcvbnm123456"
+         */
+        internal static readonly string _fakeAccessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqdW5rIiwiaWF0IjoxNjIzMTYzOTM4LCJleHAiOjI1MzM3MDgxODMzOCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.9ulEPk_mjvBivguELvlojZAUnrwkqUMnunFF6zlmKqc";
     }
 }


### PR DESCRIPTION
Intended to fix bug described in https://github.com/vmware-tanzu/tanzu-toolkit-for-visual-studio/issues/82