### PR TITLE
Access token expiration #87

### DIFF
--- a/src/Services/src/CfCli/CfCliService.cs
+++ b/src/Services/src/CfCli/CfCliService.cs
@@ -138,6 +138,14 @@ namespace Tanzu.Toolkit.Services.CfCli
             return _cachedAccessToken;
         }
 
+        public void ClearCachedAccessToken()
+        {
+            lock (_tokenLock)
+            {
+                _cachedAccessToken = null;
+            }
+        }
+
         public DetailedResult TargetApi(string apiAddress, bool skipSsl)
         {
             string args = $"{_targetApiCmd} {apiAddress}{(skipSsl ? " --skip-ssl-validation" : string.Empty)}";

--- a/src/Services/src/CfCli/ICfCliService.cs
+++ b/src/Services/src/CfCli/ICfCliService.cs
@@ -28,5 +28,6 @@ namespace Tanzu.Toolkit.Services.CfCli
         Task<DetailedResult> PushAppAsync(string appName, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string appDir, string buildpack = null, string stack = null);
         Task<Version> GetApiVersion();
         Task<DetailedResult<string>> GetRecentAppLogs(string appName);
+        void ClearCachedAccessToken();
     }
 }

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -225,8 +225,8 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         /// <summary>
         /// Requests spaces for <paramref name="org"/> using access token from <see cref="CfCliService"/>.
         /// <para>
-        /// If any exceptions are thrown when trying to retrieve orgs, this method will clear the cached
-        /// access token on <see cref="CfCliService"/> and attempt to retrieve the orgs again using a 
+        /// If any exceptions are thrown when trying to retrieve spaces, this method will clear the cached
+        /// access token on <see cref="CfCliService"/> and attempt to retrieve the spaces again using a 
         /// fresh access token.
         /// </para>
         /// </summary>
@@ -304,8 +304,8 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         /// <summary>
         /// Requests apps for <paramref name="space"/> using access token from <see cref="CfCliService"/>.
         /// <para>
-        /// If any exceptions are thrown when trying to retrieve orgs, this method will clear the cached
-        /// access token on <see cref="CfCliService"/> and attempt to retrieve the orgs again using a 
+        /// If any exceptions are thrown when trying to retrieve apps, this method will clear the cached
+        /// access token on <see cref="CfCliService"/> and attempt to retrieve the apps again using a 
         /// fresh access token.
         /// </para>
         /// </summary>
@@ -383,9 +383,9 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         /// <summary>
         /// Stop <paramref name="app"/> using token from <see cref="CfCliService"/>.
         /// <para>
-        /// If any exceptions are thrown when trying to retrieve orgs, this method will clear the cached
-        /// access token on <see cref="CfCliService"/> and attempt to retrieve the orgs again using a 
-        /// fresh access token.
+        /// If any exceptions are thrown when trying to stop, this method will clear the cached
+        /// access token on <see cref="CfCliService"/> and attempt to stop the app again using 
+        /// a fresh access token.
         /// </para>
         /// </summary>
         /// <param name="app"></param>
@@ -459,9 +459,9 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         /// <summary>
         /// Start <paramref name="app"/> using token from <see cref="CfCliService"/>.
         /// <para>
-        /// If any exceptions are thrown when trying to retrieve orgs, this method will clear the cached
-        /// access token on <see cref="CfCliService"/> and attempt to retrieve the orgs again using a 
-        /// fresh access token.
+        /// If any exceptions are thrown when trying to start, this method will clear the cached
+        /// access token on <see cref="CfCliService"/> and attempt to start the app again using 
+        /// a fresh access token.
         /// </para>
         /// </summary>
         /// <param name="app"></param>
@@ -535,9 +535,9 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         /// <summary>
         /// Delete <paramref name="app"/> using token from <see cref="CfCliService"/>.
         /// <para>
-        /// If any exceptions are thrown when trying to retrieve orgs, this method will clear the cached
-        /// access token on <see cref="CfCliService"/> and attempt to retrieve the orgs again using a 
-        /// fresh access token.
+        /// If any exceptions are thrown when trying to delete, this method will clear the cached
+        /// access token on <see cref="CfCliService"/> and attempt to delete the app again using 
+        /// a fresh access token.
         /// </para> 
         /// </summary>
         /// <param name="app"></param>

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -532,7 +532,20 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
             };
         }
 
-        public async Task<DetailedResult> DeleteAppAsync(CloudFoundryApp app, bool skipSsl = true, bool removeRoutes = true)
+        /// <summary>
+        /// Delete <paramref name="app"/> using token from <see cref="CfCliService"/>.
+        /// <para>
+        /// If any exceptions are thrown when trying to retrieve orgs, this method will clear the cached
+        /// access token on <see cref="CfCliService"/> and attempt to retrieve the orgs again using a 
+        /// fresh access token.
+        /// </para> 
+        /// </summary>
+        /// <param name="app"></param>
+        /// <param name="skipSsl"></param>
+        /// <param name="removeRoutes"></param>
+        /// <param name="retryAmount"></param>
+        /// <returns></returns>
+        public async Task<DetailedResult> DeleteAppAsync(CloudFoundryApp app, bool skipSsl = true, bool removeRoutes = true, int retryAmount = 1)
         {
             bool appWasDeleted;
 
@@ -570,15 +583,25 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
             }
             catch (Exception originalException)
             {
-                var msg = $"Something went wrong while trying to delete app '{app.AppName}': {originalException.Message}.";
-
-                _logger.Error(msg);
-
-                return new DetailedResult
+                if (retryAmount > 0)
                 {
-                    Succeeded = false,
-                    Explanation = msg,
-                };
+                    _logger.Information($"StartAppAsync caught an exception when trying to start app '{app.AppName}': {originalException.Message}. About to clear the cached access token & try again ({retryAmount} retry attempts remaining).");
+                    _cfCliService.ClearCachedAccessToken();
+                    retryAmount -= 1;
+                    return await DeleteAppAsync(app, skipSsl, removeRoutes, retryAmount);
+                }
+                else
+                {
+                    var msg = $"Something went wrong while trying to delete app '{app.AppName}': {originalException.Message}.";
+
+                    _logger.Error(msg);
+
+                    return new DetailedResult
+                    {
+                        Succeeded = false,
+                        Explanation = msg,
+                    };
+                }
             }
 
             app.State = "DELETED";

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -145,9 +145,11 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
 
         /// <summary>
         /// Requests orgs from <see cref="CfApiClient"/> using access token from <see cref="CfCliService"/>. 
+        /// <para>
         /// If any exceptions are thrown when trying to retrieve orgs, this method will clear the cached
         /// access token on <see cref="CfCliService"/> and attempt to retrieve the orgs again using a 
         /// fresh access token.
+        /// </para>
         /// </summary>
         /// <param name="cf"></param>
         /// <param name="skipSsl"></param>
@@ -222,6 +224,11 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
 
         /// <summary>
         /// Requests spaces for <paramref name="org"/> using access token from <see cref="CfCliService"/>.
+        /// <para>
+        /// If any exceptions are thrown when trying to retrieve orgs, this method will clear the cached
+        /// access token on <see cref="CfCliService"/> and attempt to retrieve the orgs again using a 
+        /// fresh access token.
+        /// </para>
         /// </summary>
         /// <param name="org"></param>
         /// <param name="skipSsl"></param>
@@ -296,6 +303,11 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
 
         /// <summary>
         /// Requests apps for <paramref name="space"/> using access token from <see cref="CfCliService"/>.
+        /// <para>
+        /// If any exceptions are thrown when trying to retrieve orgs, this method will clear the cached
+        /// access token on <see cref="CfCliService"/> and attempt to retrieve the orgs again using a 
+        /// fresh access token.
+        /// </para>
         /// </summary>
         /// <param name="space"></param>
         /// <param name="skipSsl"></param>

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -458,10 +458,15 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
 
         /// <summary>
         /// Start <paramref name="app"/> using token from <see cref="CfCliService"/>.
+        /// <para>
+        /// If any exceptions are thrown when trying to retrieve orgs, this method will clear the cached
+        /// access token on <see cref="CfCliService"/> and attempt to retrieve the orgs again using a 
+        /// fresh access token.
+        /// </para>
         /// </summary>
         /// <param name="app"></param>
         /// <param name="skipSsl"></param>
-        public async Task<DetailedResult> StartAppAsync(CloudFoundryApp app, bool skipSsl = true)
+        public async Task<DetailedResult> StartAppAsync(CloudFoundryApp app, bool skipSsl = true, int retryAmount = 1)
         {
             bool appWasStarted;
 
@@ -486,15 +491,25 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
             }
             catch (Exception originalException)
             {
-                var msg = $"Something went wrong while trying to start app '{app.AppName}': {originalException.Message}.";
-
-                _logger.Error(msg);
-
-                return new DetailedResult
+                if (retryAmount > 0)
                 {
-                    Succeeded = false,
-                    Explanation = msg,
-                };
+                    _logger.Information($"StartAppAsync caught an exception when trying to start app '{app.AppName}': {originalException.Message}. About to clear the cached access token & try again ({retryAmount} retry attempts remaining).");
+                    _cfCliService.ClearCachedAccessToken();
+                    retryAmount -= 1;
+                    return await StartAppAsync(app, skipSsl, retryAmount);
+                }
+                else
+                {
+                    var msg = $"Something went wrong while trying to start app '{app.AppName}': {originalException.Message}.";
+
+                    _logger.Error(msg);
+
+                    return new DetailedResult
+                    {
+                        Succeeded = false,
+                        Explanation = msg,
+                    };
+                }
             }
 
             if (!appWasStarted)

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -368,27 +368,6 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
             };
         }
 
-        public static void FormatExceptionMessage(Exception ex, List<string> message)
-        {
-            var aex = ex as AggregateException;
-            if (aex != null)
-            {
-                foreach (Exception iex in aex.InnerExceptions)
-                {
-                    FormatExceptionMessage(iex, message);
-                }
-            }
-            else
-            {
-                message.Add(ex.Message);
-
-                if (ex.InnerException != null)
-                {
-                    FormatExceptionMessage(ex.InnerException, message);
-                }
-            }
-        }
-
         /// <summary>
         /// Stop <paramref name="app"/> using token from <see cref="CfCliService"/>.
         /// </summary>
@@ -630,6 +609,26 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
             }
 
             return await _cfCliService.GetRecentAppLogs(app.AppName);
+        }
+
+        private void FormatExceptionMessage(Exception ex, List<string> message)
+        {
+            if (ex is AggregateException aex)
+            {
+                foreach (Exception iex in aex.InnerExceptions)
+                {
+                    FormatExceptionMessage(iex, message);
+                }
+            }
+            else
+            {
+                message.Add(ex.Message);
+
+                if (ex.InnerException != null)
+                {
+                    FormatExceptionMessage(ex.InnerException, message);
+                }
+            }
         }
 
         private static async Task MatchCliVersionToApiVersion()

--- a/src/Services/src/CloudFoundry/ICloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/ICloudFoundryService.cs
@@ -20,7 +20,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         Task<DetailedResult<List<CloudFoundryApp>>> GetAppsForSpaceAsync(CloudFoundrySpace space, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult> StopAppAsync(CloudFoundryApp app, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult> StartAppAsync(CloudFoundryApp app, bool skipSsl = true, int retryAmount = 1);
-        Task<DetailedResult> DeleteAppAsync(CloudFoundryApp app, bool skipSsl = true, bool removeRoutes = true);
+        Task<DetailedResult> DeleteAppAsync(CloudFoundryApp app, bool skipSsl = true, bool removeRoutes = true, int retryAmount = 1);
         Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string appProjPath, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback);
         void RemoveCloudFoundryInstance(string name);
         Task<DetailedResult<string>> GetRecentLogs(CloudFoundryApp app);

--- a/src/Services/src/CloudFoundry/ICloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/ICloudFoundryService.cs
@@ -17,7 +17,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         Task<ConnectResult> ConnectToCFAsync(string target, string username, SecureString password, string httpProxy, bool skipSsl);
         Task<DetailedResult<List<CloudFoundryOrganization>>> GetOrgsForCfInstanceAsync(CloudFoundryInstance cf, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult<List<CloudFoundrySpace>>> GetSpacesForOrgAsync(CloudFoundryOrganization org, bool skipSsl = true, int retryAmount = 1);
-        Task<DetailedResult<List<CloudFoundryApp>>> GetAppsForSpaceAsync(CloudFoundrySpace space, bool skipSsl = true);
+        Task<DetailedResult<List<CloudFoundryApp>>> GetAppsForSpaceAsync(CloudFoundrySpace space, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult> StopAppAsync(CloudFoundryApp app, bool skipSsl = true);
         Task<DetailedResult> StartAppAsync(CloudFoundryApp app, bool skipSsl = true);
         Task<DetailedResult> DeleteAppAsync(CloudFoundryApp app, bool skipSsl = true, bool removeRoutes = true);

--- a/src/Services/src/CloudFoundry/ICloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/ICloudFoundryService.cs
@@ -16,7 +16,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         void AddCloudFoundryInstance(string name, string apiAddress, string accessToken);
         Task<ConnectResult> ConnectToCFAsync(string target, string username, SecureString password, string httpProxy, bool skipSsl);
         Task<DetailedResult<List<CloudFoundryOrganization>>> GetOrgsForCfInstanceAsync(CloudFoundryInstance cf, bool skipSsl = true, int retryAmount = 1);
-        Task<DetailedResult<List<CloudFoundrySpace>>> GetSpacesForOrgAsync(CloudFoundryOrganization org, bool skipSsl = true);
+        Task<DetailedResult<List<CloudFoundrySpace>>> GetSpacesForOrgAsync(CloudFoundryOrganization org, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult<List<CloudFoundryApp>>> GetAppsForSpaceAsync(CloudFoundrySpace space, bool skipSsl = true);
         Task<DetailedResult> StopAppAsync(CloudFoundryApp app, bool skipSsl = true);
         Task<DetailedResult> StartAppAsync(CloudFoundryApp app, bool skipSsl = true);

--- a/src/Services/src/CloudFoundry/ICloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/ICloudFoundryService.cs
@@ -15,7 +15,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
 
         void AddCloudFoundryInstance(string name, string apiAddress, string accessToken);
         Task<ConnectResult> ConnectToCFAsync(string target, string username, SecureString password, string httpProxy, bool skipSsl);
-        Task<DetailedResult<List<CloudFoundryOrganization>>> GetOrgsForCfInstanceAsync(CloudFoundryInstance cf, bool skipSsl = true);
+        Task<DetailedResult<List<CloudFoundryOrganization>>> GetOrgsForCfInstanceAsync(CloudFoundryInstance cf, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult<List<CloudFoundrySpace>>> GetSpacesForOrgAsync(CloudFoundryOrganization org, bool skipSsl = true);
         Task<DetailedResult<List<CloudFoundryApp>>> GetAppsForSpaceAsync(CloudFoundrySpace space, bool skipSsl = true);
         Task<DetailedResult> StopAppAsync(CloudFoundryApp app, bool skipSsl = true);

--- a/src/Services/src/CloudFoundry/ICloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/ICloudFoundryService.cs
@@ -19,7 +19,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         Task<DetailedResult<List<CloudFoundrySpace>>> GetSpacesForOrgAsync(CloudFoundryOrganization org, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult<List<CloudFoundryApp>>> GetAppsForSpaceAsync(CloudFoundrySpace space, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult> StopAppAsync(CloudFoundryApp app, bool skipSsl = true, int retryAmount = 1);
-        Task<DetailedResult> StartAppAsync(CloudFoundryApp app, bool skipSsl = true);
+        Task<DetailedResult> StartAppAsync(CloudFoundryApp app, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult> DeleteAppAsync(CloudFoundryApp app, bool skipSsl = true, bool removeRoutes = true);
         Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string appProjPath, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback);
         void RemoveCloudFoundryInstance(string name);

--- a/src/Services/src/CloudFoundry/ICloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/ICloudFoundryService.cs
@@ -18,7 +18,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         Task<DetailedResult<List<CloudFoundryOrganization>>> GetOrgsForCfInstanceAsync(CloudFoundryInstance cf, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult<List<CloudFoundrySpace>>> GetSpacesForOrgAsync(CloudFoundryOrganization org, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult<List<CloudFoundryApp>>> GetAppsForSpaceAsync(CloudFoundrySpace space, bool skipSsl = true, int retryAmount = 1);
-        Task<DetailedResult> StopAppAsync(CloudFoundryApp app, bool skipSsl = true);
+        Task<DetailedResult> StopAppAsync(CloudFoundryApp app, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult> StartAppAsync(CloudFoundryApp app, bool skipSsl = true);
         Task<DetailedResult> DeleteAppAsync(CloudFoundryApp app, bool skipSsl = true, bool removeRoutes = true);
         Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string appProjPath, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback);

--- a/src/Services/test/CfCli/CfCliServiceTestSupport.cs
+++ b/src/Services/test/CfCli/CfCliServiceTestSupport.cs
@@ -24,33 +24,5 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
         internal static readonly string _fakeApps401Output = File.ReadAllText("CfCli/GetV2Apps401Output.txt");
 
         internal static readonly int _numOrgsInFakeResponse = 54;
-
-        /** this fake JWT was created using these values:
-         * HEADER:
-         * {
-         * "typ": "JWT",
-         * "alg": "HS256"
-         * }
-         * 
-         * PAYLOAD:
-         * {
-         * "iss": "junk",
-         * "iat": 1623163938,
-         * "exp": 253370818338,
-         * "aud": "www.example.com",
-         * "sub": "jrocket@example.com",
-         * "GivenName": "Johnny",
-         * "Surname": "Rocket",
-         * "Email": "jrocket@example.com",
-         * "Role": [
-         * "Manager",
-         * "Project Administrator"
-         * ]
-         * }
-         * 
-         * SIGNING KEY:
-         * "qwertyuiopasdfghjklzxcvbnm123456"
-         */
-        internal static readonly string _fakeAccessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqdW5rIiwiaWF0IjoxNjIzMTYzOTM4LCJleHAiOjI1MzM3MDgxODMzOCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.9ulEPk_mjvBivguELvlojZAUnrwkqUMnunFF6zlmKqc";
     }
 }

--- a/src/Services/test/CloudFoundry/CloudFoundryServiceTests.cs
+++ b/src/Services/test/CloudFoundry/CloudFoundryServiceTests.cs
@@ -1314,6 +1314,61 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
         }
 
         [TestMethod]
+        [TestCategory("DeleteApp")]
+        public async Task DeleteAppAsync_RetriesWithFreshToken_WhenDeleteAppWithGuidThrowsException()
+        {
+            var fakeExceptionMsg = "junk";
+
+            _mockCfCliService.SetupSequence(m => m.
+                GetOAuthToken())
+                    .Returns(expiredAccessToken) // simulate stale cached token on first attempt
+                    .Returns(_fakeValidAccessToken); // simulate fresh cached token on second attempt
+
+            _mockCfApiClient.Setup(m => m.
+                DeleteAppWithGuid(FakeApp.ParentSpace.ParentOrg.ParentCf.ApiAddress, expiredAccessToken, FakeApp.AppId))
+                    .Throws(new Exception(fakeExceptionMsg));
+
+            _mockCfApiClient.Setup(m => m.
+                DeleteAppWithGuid(FakeApp.ParentSpace.ParentOrg.ParentCf.ApiAddress, _fakeValidAccessToken, FakeApp.AppId))
+                    .ReturnsAsync(true);
+
+            var result = await _sut.DeleteAppAsync(FakeApp);
+
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Succeeded);
+            Assert.IsNull(result.Explanation);
+            Assert.IsNull(result.CmdDetails);
+
+            _mockCfCliService.Verify(m => m.ClearCachedAccessToken(), Times.Once);
+            _mockCfApiClient.Verify(m => m.DeleteAppWithGuid(FakeSpace.ParentOrg.ParentCf.ApiAddress, It.IsAny<string>(), FakeApp.AppId), Times.Exactly(2));
+            _mockLogger.Verify(m => m.Information(It.Is<string>(s => s.Contains(fakeExceptionMsg) && s.Contains("retry"))), Times.Once);
+        }
+
+        [TestMethod]
+        [TestCategory("DeleteApp")]
+        public async Task DeleteAppAsync_ReturnsFailedResult_WhenDeleteAppWithGuidThrowsException_AndThereAreZeroRetriesLeft()
+        {
+            var fakeExceptionMsg = "junk";
+
+            _mockCfCliService.Setup(m => m.
+                GetOAuthToken())
+                    .Returns(_fakeValidAccessToken);
+
+            _mockCfApiClient.Setup(m => m.
+                DeleteAppWithGuid(FakeApp.ParentSpace.ParentOrg.ParentCf.ApiAddress, _fakeValidAccessToken, FakeApp.AppId))
+                    .Throws(new Exception(fakeExceptionMsg));
+
+            DetailedResult result = await _sut.DeleteAppAsync(FakeApp, retryAmount: 0);
+
+            Assert.IsFalse(result.Succeeded);
+            Assert.IsNotNull(result.Explanation);
+            Assert.IsTrue(result.Explanation.Contains(fakeExceptionMsg));
+            Assert.IsNull(result.CmdDetails);
+
+            _mockLogger.Verify(m => m.Error(It.IsAny<string>()), Times.Once);
+        }
+
+        [TestMethod]
         [TestCategory("DeployApp")]
         public async Task DeployAppAsync_ReturnsFalseResult_WhenCfTargetCommandFails()
         {

--- a/src/Services/test/ServicesTestSupport.cs
+++ b/src/Services/test/ServicesTestSupport.cs
@@ -149,8 +149,37 @@ namespace Tanzu.Toolkit.Services.Tests
                 },
             };
 
-        static ServicesTestSupport()
-        {
-        }
+        /** this fake JWT was created using these values:
+         * HEADER:
+         * {
+         * "typ": "JWT",
+         * "alg": "HS256"
+         * }
+         * 
+         * PAYLOAD:
+         * {
+         * "iss": "junk",
+         * "iat": 1623163938,
+         * "exp": 253370818338, // year 9999
+         * "aud": "www.example.com",
+         * "sub": "jrocket@example.com",
+         * "GivenName": "Johnny",
+         * "Surname": "Rocket",
+         * "Email": "jrocket@example.com",
+         * "Role": [
+         * "Manager",
+         * "Project Administrator"
+         * ]
+         * }
+         * 
+         * SIGNING KEY:
+         * "qwertyuiopasdfghjklzxcvbnm123456"
+         */
+        internal static readonly string _fakeAccessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqdW5rIiwiaWF0IjoxNjIzMTYzOTM4LCJleHAiOjI1MzM3MDgxODMzOCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.9ulEPk_mjvBivguELvlojZAUnrwkqUMnunFF6zlmKqc";
+
+        /**
+         * This is a real JWT from the Jamestown CF environment which expired on June 8th 2021
+         */
+        internal static readonly string expiredAccessToken = "eyJhbGciOiJSUzI1NiIsImprdSI6Imh0dHBzOi8vdWFhLnN5cy5qYW1lc3Rvd24uY2YtYXBwLmNvbS90b2tlbl9rZXlzIiwia2lkIjoia2V5LTEiLCJ0eXAiOiJKV1QifQ.eyJqdGkiOiIyNmY3ZGFhNTI5MDM0OGVmOWQyZTRkYTg4MmZiMWMyZiIsInN1YiI6IjY0NzljMjY0LWE3YTQtNGRiYS05MGFmLTk1MGE4YTMyODE5ZSIsInNjb3BlIjpbIm9wZW5pZCIsInJvdXRpbmcucm91dGVyX2dyb3Vwcy53cml0ZSIsIm5ldHdvcmsud3JpdGUiLCJzY2ltLnJlYWQiLCJjbG91ZF9jb250cm9sbGVyLmFkbWluIiwidWFhLnVzZXIiLCJyb3V0aW5nLnJvdXRlcl9ncm91cHMucmVhZCIsImNsb3VkX2NvbnRyb2xsZXIucmVhZCIsInBhc3N3b3JkLndyaXRlIiwiY2xvdWRfY29udHJvbGxlci53cml0ZSIsIm5ldHdvcmsuYWRtaW4iLCJkb3BwbGVyLmZpcmVob3NlIiwic2NpbS53cml0ZSJdLCJjbGllbnRfaWQiOiJjZiIsImNpZCI6ImNmIiwiYXpwIjoiY2YiLCJncmFudF90eXBlIjoicGFzc3dvcmQiLCJ1c2VyX2lkIjoiNjQ3OWMyNjQtYTdhNC00ZGJhLTkwYWYtOTUwYThhMzI4MTllIiwib3JpZ2luIjoidWFhIiwidXNlcl9uYW1lIjoiYWRtaW4iLCJlbWFpbCI6ImFkbWluIiwiYXV0aF90aW1lIjoxNjIzMTY0ODE2LCJyZXZfc2lnIjoiNDFkOTJiYiIsImlhdCI6MTYyMzE4MTEzNSwiZXhwIjoxNjIzMTg4MzM1LCJpc3MiOiJodHRwczovL3VhYS5zeXMuamFtZXN0b3duLmNmLWFwcC5jb20vb2F1dGgvdG9rZW4iLCJ6aWQiOiJ1YWEiLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciIsInNjaW0iLCJwYXNzd29yZCIsImNmIiwidWFhIiwib3BlbmlkIiwiZG9wcGxlciIsIm5ldHdvcmsiLCJyb3V0aW5nLnJvdXRlcl9ncm91cHMiXX0.qCfIxuJb2Xv21pq9idUO44PY50n4FY1cTwpmoWbjAmVs2Cu1smeD2L8gJFSZtg04MlKEJLspfSwfsAfu4YTbUB_iWyBmrZybnZFNrU335z8jReAnHTD5Nq5wVvPLNKdwVy3VyyhHTpD7BQ-oTPLDFaVTysoqR8C13ln0Sbr8jctOHVGRS8sOxJVedtRrLAhQUtZJUPpxbq4msFa0YWLQfXRwWTUc4boYOqtHx1jXg5T2qOJDcUF8MvvLE5ROnfsRciMEtCjCqJsteIEG2lfHcE7JwH3XXSJoiz1pIBoDw1DEUplHmNgQ1saK7tNQu-gg4RVWHFKvqhnGwT94buwHkA";
     }
 }

--- a/src/Services/test/ServicesTestSupport.cs
+++ b/src/Services/test/ServicesTestSupport.cs
@@ -59,11 +59,6 @@ namespace Tanzu.Toolkit.Services.Tests
         protected const string _app3State = "STARTED";
         protected const string _app4State = "STOPPED";
 
-        protected static readonly CloudFoundryInstance FakeCfInstance = new CloudFoundryInstance("fake cf", _fakeValidTarget, _fakeValidAccessToken);
-        protected static readonly CloudFoundryOrganization FakeOrg = new CloudFoundryOrganization("fake org", "fake org guid", FakeCfInstance);
-        protected static readonly CloudFoundrySpace FakeSpace = new CloudFoundrySpace("fake space", "fake space guid", FakeOrg);
-        protected static readonly CloudFoundryApp FakeApp = new CloudFoundryApp("fake app", "fake app guid", FakeSpace, null);
-
         protected static readonly string _fakeValidTarget = "https://my.fake.target";
         protected static readonly string _fakeValidUsername = "junk";
         protected static readonly SecureString _fakeValidPassword = new SecureString();
@@ -71,6 +66,11 @@ namespace Tanzu.Toolkit.Services.Tests
         protected static readonly bool _skipSsl = true;
         protected static readonly string _fakeValidAccessToken = "valid token";
         protected static readonly string _fakeProjectPath = "this\\is\\a\\fake\\path";
+
+        protected static readonly CloudFoundryInstance FakeCfInstance = new CloudFoundryInstance("fake cf", _fakeValidTarget, _fakeValidAccessToken);
+        protected static readonly CloudFoundryOrganization FakeOrg = new CloudFoundryOrganization("fake org", "fake org guid", FakeCfInstance);
+        protected static readonly CloudFoundrySpace FakeSpace = new CloudFoundrySpace("fake space", "fake space guid", FakeOrg);
+        protected static readonly CloudFoundryApp FakeApp = new CloudFoundryApp("fake app", "fake app guid", FakeSpace, null);
 
         protected static readonly CmdResult _fakeSuccessCmdResult = new CmdResult("junk output", "junk error", 0);
         protected static readonly CmdResult _fakeFailureCmdResult = new CmdResult("junk output", "junk error", 1);

--- a/src/ViewModels/test/CfInstanceViewModelTests.cs
+++ b/src/ViewModels/test/CfInstanceViewModelTests.cs
@@ -85,7 +85,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             _receivedEvents.Clear();
 
             MockCloudFoundryService.Setup(mock => mock.
-              GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true))
+              GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true, It.IsAny<int>()))
                 .ReturnsAsync(fakeSuccessResult);
 
             Assert.AreEqual(initialOrgsList.Count, _sut.Children.Count);
@@ -106,7 +106,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             var fakeNoOrgsResult = new DetailedResult<List<CloudFoundryOrganization>>(succeeded: true, content: EmptyListOfOrgs);
 
             MockCloudFoundryService.Setup(mock => mock.
-              GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true))
+              GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true, It.IsAny<int>()))
                 .ReturnsAsync(fakeNoOrgsResult);
 
             await _sut.LoadChildren();
@@ -128,7 +128,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             var fakeOrgsResult = new DetailedResult<List<CloudFoundryOrganization>>(succeeded: true, content: EmptyListOfOrgs);
 
             MockCloudFoundryService.Setup(mock => mock.
-              GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true))
+              GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true, It.IsAny<int>()))
                 .ReturnsAsync(fakeOrgsResult);
 
             _sut.IsLoading = true;
@@ -144,7 +144,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             var fakeFailedResult = new DetailedResult<List<CloudFoundryOrganization>>(succeeded: false, content: null);
 
             MockCloudFoundryService.Setup(mock => mock.
-              GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true))
+              GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true, It.IsAny<int>()))
                 .ReturnsAsync(fakeFailedResult);
 
             _sut.IsLoading = true;
@@ -164,7 +164,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeFailureCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-              GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true))
+              GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true, It.IsAny<int>()))
                 .ReturnsAsync(fakeFailedResult);
 
             await _sut.LoadChildren();
@@ -196,7 +196,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeFailureCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-              GetOrgsForCfInstanceAsync(expandedViewModel.CloudFoundryInstance, true))
+              GetOrgsForCfInstanceAsync(expandedViewModel.CloudFoundryInstance, true, 1))
                 .ReturnsAsync(fakeFailedResult);
 
             Assert.IsTrue(expandedViewModel.IsExpanded);
@@ -224,7 +224,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             var fakeSuccessResult = new DetailedResult<List<CloudFoundryOrganization>>(succeeded: true, content: fakeOrgsList);
 
             MockCloudFoundryService.Setup(mock => mock.
-              GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true))
+              GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true, It.IsAny<int>()))
                 .ReturnsAsync(fakeSuccessResult);
 
             /* pre-check presence of placeholder */
@@ -253,7 +253,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeFailureCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-              GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true))
+              GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true, It.IsAny<int>()))
                 .ReturnsAsync(fakeFailedResult);
 
             var result = await _sut.FetchChildren();
@@ -311,7 +311,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             Assert.IsFalse(initialChildOrg3.IsExpanded);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true))
+                GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeSuccessResult);
 
             _receivedEvents.Clear();
@@ -350,7 +350,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true))
+                GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeEmptyOrgsResult);
 
             _sut.Children = new ObservableCollection<TreeViewItemViewModel> { ovm }; // simulate cf initially having 1 org child
@@ -385,7 +385,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true))
+                GetOrgsForCfInstanceAsync(_sut.CloudFoundryInstance, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeSuccessfulOrgsResult);
 
             Assert.AreEqual(1, _sut.Children.Count);

--- a/src/ViewModels/test/CloudExplorerViewModelTests.cs
+++ b/src/ViewModels/test/CloudExplorerViewModelTests.cs
@@ -266,7 +266,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         {
             var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
-            MockCloudFoundryService.Setup(mock => mock.DeleteAppAsync(fakeApp, true, true)).ReturnsAsync(FakeSuccessDetailedResult);
+            MockCloudFoundryService.Setup(mock => mock.DeleteAppAsync(fakeApp, true, true, It.IsAny<int>())).ReturnsAsync(FakeSuccessDetailedResult);
 
             Exception shouldStayNull = null;
             try
@@ -288,7 +288,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             MockCloudFoundryService.Setup(mock => mock.
-                DeleteAppAsync(fakeApp, true, true))
+                DeleteAppAsync(fakeApp, true, true, It.IsAny<int>()))
                     .ReturnsAsync(FakeFailureDetailedResult);
 
             await _sut.DeleteCfApp(fakeApp);
@@ -307,7 +307,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             MockCloudFoundryService.Setup(mock => mock.
-                DeleteAppAsync(fakeApp, true, true))
+                DeleteAppAsync(fakeApp, true, true, It.IsAny<int>()))
                     .ReturnsAsync(FakeFailureDetailedResult);
 
             await _sut.DeleteCfApp(fakeApp);

--- a/src/ViewModels/test/CloudExplorerViewModelTests.cs
+++ b/src/ViewModels/test/CloudExplorerViewModelTests.cs
@@ -401,7 +401,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             // simulate addition of new Space
             MockCloudFoundryService.Setup(mock => mock.
-                GetSpacesForOrgAsync(fakeInitialOrg, true))
+                GetSpacesForOrgAsync(fakeInitialOrg, true, It.IsAny<int>()))
                     .ReturnsAsync(new DetailedResult<List<CloudFoundrySpace>>(
                 succeeded: true,
                 content: new List<CloudFoundrySpace>
@@ -476,7 +476,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             // No need to get children for orgs that were just added by refresh.
             MockCloudFoundryService.Verify(mock => mock.
-                GetSpacesForOrgAsync(fakeNewOrg, true), Times.Never);
+                GetSpacesForOrgAsync(fakeNewOrg, true, It.IsAny<int>()), Times.Never);
 
             // No need to get children for spaces that were just added by refresh.
             MockCloudFoundryService.Verify(mock => mock.
@@ -741,7 +741,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                         cmdDetails: FakeSuccessCmdResult));
             
             MockCloudFoundryService.Setup(mock => mock.
-                GetSpacesForOrgAsync(fakeInitialOrg, true))
+                GetSpacesForOrgAsync(fakeInitialOrg, true, It.IsAny<int>()))
                     .ReturnsAsync(new DetailedResult<List<CloudFoundrySpace>>(
                         succeeded: true,
                         content: new List<CloudFoundrySpace>

--- a/src/ViewModels/test/CloudExplorerViewModelTests.cs
+++ b/src/ViewModels/test/CloudExplorerViewModelTests.cs
@@ -146,7 +146,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         {
             var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
-            MockCloudFoundryService.Setup(mock => mock.StopAppAsync(fakeApp, true)).ReturnsAsync(FakeSuccessDetailedResult);
+            MockCloudFoundryService.Setup(mock => mock.StopAppAsync(fakeApp, true, It.IsAny<int>())).ReturnsAsync(FakeSuccessDetailedResult);
 
             Exception shouldStayNull = null;
             try
@@ -168,7 +168,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             MockCloudFoundryService.Setup(mock => mock.
-                StopAppAsync(fakeApp, true))
+                StopAppAsync(fakeApp, true, It.IsAny<int>()))
                     .ReturnsAsync(FakeFailureDetailedResult);
 
             await _sut.StopCfApp(fakeApp);
@@ -187,7 +187,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             MockCloudFoundryService.Setup(mock => mock.
-                StopAppAsync(fakeApp, true))
+                StopAppAsync(fakeApp, true, It.IsAny<int>()))
                     .ReturnsAsync(FakeFailureDetailedResult);
 
             await _sut.StopCfApp(fakeApp);

--- a/src/ViewModels/test/CloudExplorerViewModelTests.cs
+++ b/src/ViewModels/test/CloudExplorerViewModelTests.cs
@@ -414,7 +414,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             // simulate addition of new App + change of state for initial app
             MockCloudFoundryService.Setup(mock => mock.
-                GetAppsForSpaceAsync(fakeInitialSpace, true))
+                GetAppsForSpaceAsync(fakeInitialSpace, true, It.IsAny<int>()))
                     .ReturnsAsync(new DetailedResult<List<CloudFoundryApp>>(
                 succeeded: true,
                 content: new List<CloudFoundryApp>
@@ -468,7 +468,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             Assert.AreEqual(fakeNewApp.AppId, secondAppVm.App.AppId);
 
             // ensure space refresh makes request for fresh apps
-            MockCloudFoundryService.Verify(mock => mock.GetAppsForSpaceAsync(fakeInitialSpace, true), Times.Once);
+            MockCloudFoundryService.Verify(mock => mock.GetAppsForSpaceAsync(fakeInitialSpace, true, It.IsAny<int>()), Times.Once);
 
             // No need to get children for CFs that were just added by refresh.
             MockCloudFoundryService.Verify(mock => mock.
@@ -480,7 +480,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             // No need to get children for spaces that were just added by refresh.
             MockCloudFoundryService.Verify(mock => mock.
-                GetAppsForSpaceAsync(fakeNewSpace, true), Times.Never);
+                GetAppsForSpaceAsync(fakeNewSpace, true, It.IsAny<int>()), Times.Never);
         }
 
         [TestMethod]

--- a/src/ViewModels/test/CloudExplorerViewModelTests.cs
+++ b/src/ViewModels/test/CloudExplorerViewModelTests.cs
@@ -388,7 +388,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             // simulate addition of new Org
             MockCloudFoundryService.Setup(mock => mock.
-                GetOrgsForCfInstanceAsync(fakeInitialCfInstance, true))
+                GetOrgsForCfInstanceAsync(fakeInitialCfInstance, true, 1))
                     .ReturnsAsync(new DetailedResult<List<CloudFoundryOrganization>>(
                         succeeded: true,
                         content: new List<CloudFoundryOrganization>
@@ -472,7 +472,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             // No need to get children for CFs that were just added by refresh.
             MockCloudFoundryService.Verify(mock => mock.
-                GetOrgsForCfInstanceAsync(fakeNewCfInstance, true), Times.Never);
+                GetOrgsForCfInstanceAsync(fakeNewCfInstance, true, It.IsAny<int>()), Times.Never);
 
             // No need to get children for orgs that were just added by refresh.
             MockCloudFoundryService.Verify(mock => mock.
@@ -505,7 +505,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                     });
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetOrgsForCfInstanceAsync(fakeInitialCfInstance, true))
+                GetOrgsForCfInstanceAsync(fakeInitialCfInstance, true, 1))
                     .ReturnsAsync(new DetailedResult<List<CloudFoundryOrganization>>(
                         succeeded: true,
                         content: new List<CloudFoundryOrganization>
@@ -555,7 +555,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                     });
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetOrgsForCfInstanceAsync(fakeInitialCfInstance, true))
+                GetOrgsForCfInstanceAsync(fakeInitialCfInstance, true, 1))
                     .ReturnsAsync(new DetailedResult<List<CloudFoundryOrganization>>(
                         succeeded: true,
                         content: new List<CloudFoundryOrganization>
@@ -660,7 +660,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                     });
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetOrgsForCfInstanceAsync(fakeInitialCfInstance, true))
+                GetOrgsForCfInstanceAsync(fakeInitialCfInstance, true, 1))
                     .ReturnsAsync(new DetailedResult<List<CloudFoundryOrganization>>(
                         succeeded: true,
                         content: new List<CloudFoundryOrganization>
@@ -730,7 +730,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                     });
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetOrgsForCfInstanceAsync(fakeInitialCfInstance, true))
+                GetOrgsForCfInstanceAsync(fakeInitialCfInstance, true, 1))
                     .ReturnsAsync(new DetailedResult<List<CloudFoundryOrganization>>(
                         succeeded: true,
                         content: new List<CloudFoundryOrganization>

--- a/src/ViewModels/test/CloudExplorerViewModelTests.cs
+++ b/src/ViewModels/test/CloudExplorerViewModelTests.cs
@@ -206,7 +206,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         {
             var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
-            MockCloudFoundryService.Setup(mock => mock.StartAppAsync(fakeApp, true)).ReturnsAsync(FakeSuccessDetailedResult);
+            MockCloudFoundryService.Setup(mock => mock.StartAppAsync(fakeApp, true, It.IsAny<int>())).ReturnsAsync(FakeSuccessDetailedResult);
 
             Exception shouldStayNull = null;
             try
@@ -228,7 +228,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             MockCloudFoundryService.Setup(mock => mock.
-                StartAppAsync(fakeApp, true))
+                StartAppAsync(fakeApp, true, It.IsAny<int>()))
                     .ReturnsAsync(FakeFailureDetailedResult);
 
             await _sut.StartCfApp(fakeApp);
@@ -247,7 +247,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             var fakeApp = new CloudFoundryApp("junk", "junk", parentSpace: null, null);
 
             MockCloudFoundryService.Setup(mock => mock.
-                StartAppAsync(fakeApp, true))
+                StartAppAsync(fakeApp, true, It.IsAny<int>()))
                     .ReturnsAsync(FakeFailureDetailedResult);
 
             await _sut.StartCfApp(fakeApp);

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -329,7 +329,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetOrgsForCfInstanceAsync(FakeCfInstance, true))
+                GetOrgsForCfInstanceAsync(FakeCfInstance, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeSuccessfulOrgsResponse);
 
             _sut.SelectedCf = FakeCfInstance;
@@ -368,7 +368,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeFailureCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetOrgsForCfInstanceAsync(FakeCfInstance, true))
+                GetOrgsForCfInstanceAsync(FakeCfInstance, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeFailedOrgsResponse);
 
             MockDialogService.Setup(mock => mock.
@@ -395,7 +395,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeFailureCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetOrgsForCfInstanceAsync(FakeCfInstance, true))
+                GetOrgsForCfInstanceAsync(FakeCfInstance, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeFailedOrgsResponse);
 
             MockDialogService.Setup(mock => mock.

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -423,7 +423,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetSpacesForOrgAsync(FakeCfOrg, true))
+                GetSpacesForOrgAsync(FakeCfOrg, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeSuccessfulSpacesResponse);
 
             _sut.SelectedCf = FakeCfInstance;
@@ -475,7 +475,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeFailureCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetSpacesForOrgAsync(FakeCfOrg, true))
+                GetSpacesForOrgAsync(FakeCfOrg, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeFailedSpacesResponse);
 
             MockDialogService.Setup(mock => mock.
@@ -504,7 +504,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeFailureCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetSpacesForOrgAsync(FakeCfOrg, true))
+                GetSpacesForOrgAsync(FakeCfOrg, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeFailedSpacesResponse);
 
             MockDialogService.Setup(mock => mock.

--- a/src/ViewModels/test/OrgViewModelTests.cs
+++ b/src/ViewModels/test/OrgViewModelTests.cs
@@ -89,7 +89,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             _receivedEvents.Clear();
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetSpacesForOrgAsync(It.IsAny<CloudFoundryOrganization>(), true))
+                GetSpacesForOrgAsync(It.IsAny<CloudFoundryOrganization>(), true, It.IsAny<int>()))
                     .ReturnsAsync(fakeSucccessResponse);
 
             Assert.AreEqual(initialSpacesList.Count, _sut.Children.Count);
@@ -114,7 +114,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetSpacesForOrgAsync(It.IsAny<CloudFoundryOrganization>(), true))
+                GetSpacesForOrgAsync(It.IsAny<CloudFoundryOrganization>(), true, It.IsAny<int>()))
                     .ReturnsAsync(fakeNoSpacesResponse);
 
             await _sut.LoadChildren();
@@ -140,7 +140,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetSpacesForOrgAsync(_sut.Org, true))
+                GetSpacesForOrgAsync(_sut.Org, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeNoSpacesResponse);
 
             _sut.IsLoading = true;
@@ -160,7 +160,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeFailureCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-              GetSpacesForOrgAsync(_sut.Org, true))
+              GetSpacesForOrgAsync(_sut.Org, true, It.IsAny<int>()))
                 .ReturnsAsync(fakeFailedResult);
 
             await _sut.LoadChildren();
@@ -188,7 +188,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetSpacesForOrgAsync(FakeCfOrg, true))
+                GetSpacesForOrgAsync(FakeCfOrg, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeSuccessResponse);
 
             /* pre-check presence of placeholder */
@@ -217,7 +217,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeFailureCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-              GetSpacesForOrgAsync(_sut.Org, true))
+              GetSpacesForOrgAsync(_sut.Org, true, It.IsAny<int>()))
                 .ReturnsAsync(fakeFailedResult);
 
             var result = await _sut.FetchChildren();
@@ -275,7 +275,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             Assert.IsFalse(initialChildSpace3.IsExpanded);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetSpacesForOrgAsync(_sut.Org, true))
+                GetSpacesForOrgAsync(_sut.Org, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeSuccessResult);
 
             _receivedEvents.Clear();
@@ -314,7 +314,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetSpacesForOrgAsync(_sut.Org, true))
+                GetSpacesForOrgAsync(_sut.Org, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeNoSpacesResult);
 
             _sut.Children = new ObservableCollection<TreeViewItemViewModel> { svm }; // simulate org initially having 1 space child
@@ -349,7 +349,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetSpacesForOrgAsync(_sut.Org, true))
+                GetSpacesForOrgAsync(_sut.Org, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeSuccessfulSpacesResult);
 
             _sut.Children = new ObservableCollection<TreeViewItemViewModel> { _sut.EmptyPlaceholder }; // simulate org initially having no space children

--- a/src/ViewModels/test/SpaceViewModelTests.cs
+++ b/src/ViewModels/test/SpaceViewModelTests.cs
@@ -89,7 +89,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             _receivedEvents.Clear();
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetAppsForSpaceAsync(_sut.Space, true))
+                GetAppsForSpaceAsync(_sut.Space, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeAppsResult);
 
             Assert.AreEqual(initialAppsList.Count, _sut.Children.Count);
@@ -114,7 +114,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetAppsForSpaceAsync(_sut.Space, true))
+                GetAppsForSpaceAsync(_sut.Space, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeAppsResult);
 
             await _sut.LoadChildren();
@@ -140,7 +140,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetAppsForSpaceAsync(_sut.Space, true))
+                GetAppsForSpaceAsync(_sut.Space, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeAppsResult);
 
             _sut.IsLoading = true;
@@ -166,7 +166,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetAppsForSpaceAsync(_sut.Space, true))
+                GetAppsForSpaceAsync(_sut.Space, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeAppsResult);
 
             /* pre-check presence of placeholder */
@@ -195,7 +195,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeFailureCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-              GetAppsForSpaceAsync(_sut.Space, true))
+              GetAppsForSpaceAsync(_sut.Space, true, It.IsAny<int>()))
                 .ReturnsAsync(fakeFailedResult);
 
             await _sut.LoadChildren();
@@ -217,7 +217,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeFailureCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-              GetAppsForSpaceAsync(_sut.Space, true))
+              GetAppsForSpaceAsync(_sut.Space, true, It.IsAny<int>()))
                 .ReturnsAsync(fakeFailedResult);
 
             var result = await _sut.FetchChildren();
@@ -278,7 +278,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             Assert.AreEqual(initialState3, initialChildApp3.App.State);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetAppsForSpaceAsync(_sut.Space, true))
+                GetAppsForSpaceAsync(_sut.Space, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeSuccessResult);
 
             _receivedEvents.Clear();
@@ -318,7 +318,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetAppsForSpaceAsync(_sut.Space, true))
+                GetAppsForSpaceAsync(_sut.Space, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeNoAppsResult);
 
             _sut.Children = new ObservableCollection<TreeViewItemViewModel> { avm }; // simulate space initially having 1 app child
@@ -354,7 +354,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetAppsForSpaceAsync(_sut.Space, true))
+                GetAppsForSpaceAsync(_sut.Space, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeSuccessfulAppsResult);
 
             _sut.Children = new ObservableCollection<TreeViewItemViewModel> { _sut.EmptyPlaceholder }; // simulate space initially having no app children
@@ -404,7 +404,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 cmdDetails: FakeSuccessCmdResult);
 
             MockCloudFoundryService.Setup(mock => mock.
-                GetAppsForSpaceAsync(_sut.Space, true))
+                GetAppsForSpaceAsync(_sut.Space, true, It.IsAny<int>()))
                     .ReturnsAsync(fakeSuccessfulAppsResult);
 
             await _sut.RefreshChildren();


### PR DESCRIPTION
In case a token is ever invalidated before it reaches the end of its prescribed lifetime, these changes will make sure any failed CF operations get retried (1 time by default) with a fresh access token.

_Note_: Only the CF operations which rely on the CfApiClient were changed; the CF CLI has this token-refreshing behavior built-in.

_Consequence_: If we enter a scenario where an access token becomes invalid before the end of its prescribed lifetime, and the next CF operation that gets run relies on the CF CLI instead of CfApiClient, the CF CLI will refresh the value for the access token in its config file (`~/.cf/config.json` by default), but this will result in a "stale" value for the access token that gets cached in `CfCliService` (updates to the config file do not automatically trigger any updates for this cached token value in `CfCliService`). 
This is ok, though, because the next CF operation will now be able to succeed regardless of whether it relies on the CF CLI or the CfApiClient. In the former case, the token value will be read directly from the CF CLI config file (this will be a fresh value for the token, so the operation will succeed). In the latter case, the CF operation might _initially_ fail if it uses a "stale" value for the access token, but -- as of these changes -- it will clear the cached token value from `CfCliService` & retry the same operation again using a fresh token value.