### PR TITLE
Cf target thread safety #94

### DIFF
--- a/src/Services/src/CfCli/ICfCliService.cs
+++ b/src/Services/src/CfCli/ICfCliService.cs
@@ -17,15 +17,15 @@ namespace Tanzu.Toolkit.Services.CfCli
         DetailedResult ExecuteCfCliCommand(string arguments, string workingDir = null);
         Task<DetailedResult<List<Org>>> GetOrgsAsync();
         Task<DetailedResult<List<Space>>> GetSpacesAsync();
-        Task<DetailedResult> TargetOrg(string orgName);
-        Task<DetailedResult> TargetSpace(string spaceName);
+        DetailedResult TargetOrg(string orgName);
+        DetailedResult TargetSpace(string spaceName);
         Task<DetailedResult<List<App>>> GetAppsAsync();
         Task<DetailedResult> StopAppByNameAsync(string appName);
         Task<DetailedResult> StartAppByNameAsync(string appName);
         Task<DetailedResult> DeleteAppByNameAsync(string appName, bool removeMappedRoutes = true);
         Task<DetailedResult> PushAppAsync(string appName, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string appDir, string buildpack = null, string stack = null);
         Task<Version> GetApiVersion();
-        Task<DetailedResult<string>> GetRecentAppLogs(string appName);
+        Task<DetailedResult<string>> GetRecentAppLogs(string appName, string orgName, string spaceName);
         void ClearCachedAccessToken();
     }
 }

--- a/src/Services/src/CfCli/ICfCliService.cs
+++ b/src/Services/src/CfCli/ICfCliService.cs
@@ -23,7 +23,7 @@ namespace Tanzu.Toolkit.Services.CfCli
         Task<DetailedResult> StopAppByNameAsync(string appName);
         Task<DetailedResult> StartAppByNameAsync(string appName);
         Task<DetailedResult> DeleteAppByNameAsync(string appName, bool removeMappedRoutes = true);
-        Task<DetailedResult> PushAppAsync(string appName, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string appDir, string buildpack = null, string stack = null);
+        Task<DetailedResult> PushAppAsync(string appName, string orgName, string spaceName, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string appDir, string buildpack = null, string stack = null);
         Task<Version> GetApiVersion();
         Task<DetailedResult<string>> GetRecentAppLogs(string appName, string orgName, string spaceName);
         void ClearCachedAccessToken();

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -618,26 +618,6 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
                 return new DetailedResult(false, EmptyOutputDirMessage);
             }
 
-            var targetOrgResult = _cfCliService.TargetOrg(targetOrg.OrgName);
-            if (!targetOrgResult.Succeeded)
-            {
-                return new DetailedResult<string>(
-                content: null,
-                succeeded: false,
-                targetOrgResult.Explanation,
-                targetOrgResult.CmdDetails);
-            }
-
-            var targetSpaceResult = _cfCliService.TargetSpace(targetSpace.SpaceName);
-            if (!targetSpaceResult.Succeeded)
-            {
-                return new DetailedResult<string>(
-                content: null,
-                succeeded: false,
-                targetSpaceResult.Explanation,
-                targetSpaceResult.CmdDetails);
-            }
-
             string buildpack = null;
             string stack = null;
             if (fullFrameworkDeployment)
@@ -646,7 +626,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
                 stack = "windows";
             }
 
-            DetailedResult cfPushResult = await _cfCliService.PushAppAsync(appName, stdOutCallback, stdErrCallback, appProjPath, buildpack, stack);
+            DetailedResult cfPushResult = await _cfCliService.PushAppAsync(appName, targetOrg.OrgName, targetSpace.SpaceName, stdOutCallback, stdErrCallback, appProjPath, buildpack, stack);
 
             if (!cfPushResult.Succeeded)
             {

--- a/src/Services/test/CfCli/CfCliServiceTests.cs
+++ b/src/Services/test/CfCli/CfCliServiceTests.cs
@@ -991,12 +991,22 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
         {
             var fakeAppName = "my fake app";
             string expectedArgs = $"push \"{fakeAppName}\""; // ensure app name gets surrounded by quotes
+            var expectedTargetOrgCmdArgs = $"{CfCliService._targetOrgCmd} {FakeOrg.OrgName}";
+            var expectedTargetSpaceCmdArgs = $"{CfCliService._targetSpaceCmd} {FakeSpace.SpaceName}";
+
+            _mockCmdProcessService.Setup(m => m.
+              RunCommand(_fakePathToCfExe, expectedTargetOrgCmdArgs, null, null, null))
+                .Returns(_fakeSuccessCmdResult);
+
+            _mockCmdProcessService.Setup(m => m.
+              RunCommand(_fakePathToCfExe, expectedTargetSpaceCmdArgs, null, null, null))
+                .Returns(_fakeSuccessCmdResult);
 
             _mockCmdProcessService.Setup(m => m.
                 RunCommand(_fakePathToCfExe, expectedArgs, _fakeProjectPath, null, null))
                     .Returns(_fakeSuccessCmdResult);
 
-            var result = await _sut.PushAppAsync(fakeAppName, null, null, _fakeProjectPath);
+            var result = await _sut.PushAppAsync(fakeAppName, FakeOrg.OrgName, FakeSpace.SpaceName, null, null, _fakeProjectPath);
 
             Assert.IsTrue(result.Succeeded);
             Assert.IsNull(result.Explanation);
@@ -1010,12 +1020,22 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
             var fakeAppName = "my fake app";
             var fakeStackValue = "my-cool-stack-name";
             string expectedArgs = $"push \"{fakeAppName}\" -s {fakeStackValue}"; // ensure app name gets surrounded by quotes
+            var expectedTargetOrgCmdArgs = $"{CfCliService._targetOrgCmd} {FakeOrg.OrgName}";
+            var expectedTargetSpaceCmdArgs = $"{CfCliService._targetSpaceCmd} {FakeSpace.SpaceName}";
+
+            _mockCmdProcessService.Setup(m => m.
+               RunCommand(_fakePathToCfExe, expectedTargetOrgCmdArgs, null, null, null))
+                .Returns(_fakeSuccessCmdResult);
+
+            _mockCmdProcessService.Setup(m => m.
+              RunCommand(_fakePathToCfExe, expectedTargetSpaceCmdArgs, null, null, null))
+                .Returns(_fakeSuccessCmdResult);
 
             _mockCmdProcessService.Setup(m => m.
                 RunCommand(_fakePathToCfExe, expectedArgs, _fakeProjectPath, null, null))
                     .Returns(_fakeSuccessCmdResult);
 
-            var result = await _sut.PushAppAsync(fakeAppName, null, null, _fakeProjectPath, stack: fakeStackValue);
+            var result = await _sut.PushAppAsync(fakeAppName, FakeOrg.OrgName, FakeSpace.SpaceName, null, null, _fakeProjectPath, stack: fakeStackValue);
 
             Assert.IsTrue(result.Succeeded);
             Assert.IsNull(result.Explanation);
@@ -1029,12 +1049,22 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
             var fakeAppName = "my fake app";
             var fakeBuildpackValue = "my-cool-buildpack";
             string expectedArgs = $"push \"{fakeAppName}\" -b {fakeBuildpackValue}"; // ensure app name gets surrounded by quotes
+            var expectedTargetOrgCmdArgs = $"{CfCliService._targetOrgCmd} {FakeOrg.OrgName}";
+            var expectedTargetSpaceCmdArgs = $"{CfCliService._targetSpaceCmd} {FakeSpace.SpaceName}";
+
+            _mockCmdProcessService.Setup(m => m.
+              RunCommand(_fakePathToCfExe, expectedTargetOrgCmdArgs, null, null, null))
+                .Returns(_fakeSuccessCmdResult);
+
+            _mockCmdProcessService.Setup(m => m.
+              RunCommand(_fakePathToCfExe, expectedTargetSpaceCmdArgs, null, null, null))
+                .Returns(_fakeSuccessCmdResult);
 
             _mockCmdProcessService.Setup(m => m.
                 RunCommand(_fakePathToCfExe, expectedArgs, _fakeProjectPath, null, null))
                     .Returns(_fakeSuccessCmdResult);
 
-            var result = await _sut.PushAppAsync(fakeAppName, null, null, _fakeProjectPath, buildpack: fakeBuildpackValue);
+            var result = await _sut.PushAppAsync(fakeAppName, FakeOrg.OrgName, FakeSpace.SpaceName, null, null, _fakeProjectPath, buildpack: fakeBuildpackValue);
 
             Assert.IsTrue(result.Succeeded);
             Assert.IsNull(result.Explanation);
@@ -1049,12 +1079,22 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
             var fakeStackValue = "my-cool-stack";
             var fakeBuildpackValue = "my-cool-buildpack";
             string expectedArgs = $"push \"{fakeAppName}\" -b {fakeBuildpackValue} -s {fakeStackValue}"; // ensure app name gets surrounded by quotes
+            var expectedTargetOrgCmdArgs = $"{CfCliService._targetOrgCmd} {FakeOrg.OrgName}";
+            var expectedTargetSpaceCmdArgs = $"{CfCliService._targetSpaceCmd} {FakeSpace.SpaceName}";
+
+            _mockCmdProcessService.Setup(m => m.
+              RunCommand(_fakePathToCfExe, expectedTargetOrgCmdArgs, null, null, null))
+                .Returns(_fakeSuccessCmdResult);
+
+            _mockCmdProcessService.Setup(m => m.
+              RunCommand(_fakePathToCfExe, expectedTargetSpaceCmdArgs, null, null, null))
+                .Returns(_fakeSuccessCmdResult);
 
             _mockCmdProcessService.Setup(m => m.
                 RunCommand(_fakePathToCfExe, expectedArgs, _fakeProjectPath, null, null))
                     .Returns(_fakeSuccessCmdResult);
 
-            var result = await _sut.PushAppAsync(fakeAppName, null, null, _fakeProjectPath, buildpack: fakeBuildpackValue, stack: fakeStackValue);
+            var result = await _sut.PushAppAsync(fakeAppName, FakeOrg.OrgName, FakeSpace.SpaceName, null, null, _fakeProjectPath, buildpack: fakeBuildpackValue, stack: fakeStackValue);
 
             Assert.IsTrue(result.Succeeded);
             Assert.IsNull(result.Explanation);
@@ -1070,7 +1110,7 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
                 FullPathToCfExe)
                     .Returns((string)null);
 
-            var result = await _sut.PushAppAsync(fakeAppName, null, null, _fakeProjectPath);
+            var result = await _sut.PushAppAsync(fakeAppName, FakeOrg.OrgName, FakeSpace.SpaceName, null, null, _fakeProjectPath);
 
             Assert.IsFalse(result.Succeeded);
             Assert.IsNull(result.CmdDetails);
@@ -1079,16 +1119,76 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
 
         [TestMethod]
         [TestCategory("PushApp")]
+        public async Task PushAppAsync_ReturnsFailureResult_WhenTargetOrgFails()
+        {
+            var fakeAppName = "my fake app";
+            string expectedArgs = $"push \"{fakeAppName}\""; // ensure app name gets surrounded by quotes
+            var expectedTargetOrgCmdArgs = $"{CfCliService._targetOrgCmd} {FakeOrg.OrgName}";
+            var expectedTargetSpaceCmdArgs = $"{CfCliService._targetSpaceCmd} {FakeSpace.SpaceName}";
+
+            _mockCmdProcessService.Setup(m => m.
+              RunCommand(_fakePathToCfExe, expectedTargetOrgCmdArgs, null, null, null))
+                .Returns(_fakeFailureCmdResult);
+
+            var result = await _sut.PushAppAsync(fakeAppName, FakeOrg.OrgName, FakeSpace.SpaceName, null, null, _fakeProjectPath);
+
+            Assert.IsFalse(result.Succeeded);
+            Assert.IsTrue(result.Explanation.Contains("Unable to deploy"));
+            Assert.IsTrue(result.Explanation.Contains(fakeAppName));
+            Assert.IsTrue(result.Explanation.Contains("failed to target org"));
+            Assert.IsTrue(result.Explanation.Contains(FakeOrg.OrgName));
+            Assert.AreEqual(_fakeFailureCmdResult, result.CmdDetails);
+        }
+        
+        [TestMethod]
+        [TestCategory("PushApp")]
+        public async Task PushAppAsync_ReturnsFailureResult_WhenTargetSpaceFails()
+        {
+            var fakeAppName = "my fake app";
+            string expectedArgs = $"push \"{fakeAppName}\""; // ensure app name gets surrounded by quotes
+            var expectedTargetOrgCmdArgs = $"{CfCliService._targetOrgCmd} {FakeOrg.OrgName}";
+            var expectedTargetSpaceCmdArgs = $"{CfCliService._targetSpaceCmd} {FakeSpace.SpaceName}";
+
+            _mockCmdProcessService.Setup(m => m.
+              RunCommand(_fakePathToCfExe, expectedTargetOrgCmdArgs, null, null, null))
+                .Returns(_fakeSuccessCmdResult);
+
+            _mockCmdProcessService.Setup(m => m.
+              RunCommand(_fakePathToCfExe, expectedTargetSpaceCmdArgs, null, null, null))
+                .Returns(_fakeFailureCmdResult);
+
+            var result = await _sut.PushAppAsync(fakeAppName, FakeOrg.OrgName, FakeSpace.SpaceName, null, null, _fakeProjectPath);
+
+            Assert.IsFalse(result.Succeeded);
+            Assert.IsTrue(result.Explanation.Contains("Unable to deploy"));
+            Assert.IsTrue(result.Explanation.Contains(fakeAppName));
+            Assert.IsTrue(result.Explanation.Contains("failed to target space"));
+            Assert.IsTrue(result.Explanation.Contains(FakeSpace.SpaceName));
+            Assert.AreEqual(_fakeFailureCmdResult, result.CmdDetails);
+        }
+        
+        [TestMethod]
+        [TestCategory("PushApp")]
         public async Task PushAppAsync_ReturnsFailureResult_WhenCfCmdFails()
         {
             var fakeAppName = "my fake app";
             string expectedArgs = $"push \"{fakeAppName}\""; // ensure app name gets surrounded by quotes
+            var expectedTargetOrgCmdArgs = $"{CfCliService._targetOrgCmd} {FakeOrg.OrgName}";
+            var expectedTargetSpaceCmdArgs = $"{CfCliService._targetSpaceCmd} {FakeSpace.SpaceName}";
+
+            _mockCmdProcessService.Setup(m => m.
+              RunCommand(_fakePathToCfExe, expectedTargetOrgCmdArgs, null, null, null))
+                .Returns(_fakeSuccessCmdResult);
+
+            _mockCmdProcessService.Setup(m => m.
+              RunCommand(_fakePathToCfExe, expectedTargetSpaceCmdArgs, null, null, null))
+                .Returns(_fakeSuccessCmdResult);
 
             _mockCmdProcessService.Setup(m => m.
                 RunCommand(_fakePathToCfExe, expectedArgs, _fakeProjectPath, null, null))
                     .Returns(_fakeFailureCmdResult);
 
-            var result = await _sut.PushAppAsync(fakeAppName, null, null, _fakeProjectPath);
+            var result = await _sut.PushAppAsync(fakeAppName, FakeOrg.OrgName, FakeSpace.SpaceName, null, null, _fakeProjectPath);
 
             Assert.IsFalse(result.Succeeded);
             Assert.AreEqual(_fakeFailureCmdResult.StdErr, result.Explanation);
@@ -1101,13 +1201,23 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
         {
             var fakeAppName = "my fake app";
             string expectedArgs = $"push \"{fakeAppName}\""; // ensure app name gets surrounded by quotes
+            var expectedTargetOrgCmdArgs = $"{CfCliService._targetOrgCmd} {FakeOrg.OrgName}";
+            var expectedTargetSpaceCmdArgs = $"{CfCliService._targetSpaceCmd} {FakeSpace.SpaceName}";
             CmdResult mockFailedResult = new CmdResult("Something went wrong but there's no StdErr!", "", 1);
 
             _mockCmdProcessService.Setup(m => m.
                 RunCommand(_fakePathToCfExe, expectedArgs, _fakeProjectPath, null, null))
                     .Returns(mockFailedResult);
 
-            var result = await _sut.PushAppAsync(fakeAppName, null, null, _fakeProjectPath);
+            _mockCmdProcessService.Setup(m => m.
+              RunCommand(_fakePathToCfExe, expectedTargetOrgCmdArgs, null, null, null))
+                .Returns(_fakeSuccessCmdResult);
+
+            _mockCmdProcessService.Setup(m => m.
+              RunCommand(_fakePathToCfExe, expectedTargetSpaceCmdArgs, null, null, null))
+                .Returns(_fakeSuccessCmdResult);
+
+            var result = await _sut.PushAppAsync(fakeAppName, FakeOrg.OrgName, FakeSpace.SpaceName, null, null, _fakeProjectPath);
 
             Assert.IsFalse(result.Succeeded);
             Assert.AreEqual($"Unable to execute `cf {expectedArgs}`.", result.Explanation);

--- a/src/Services/test/CloudFoundry/CloudFoundryServiceTests.cs
+++ b/src/Services/test/CloudFoundry/CloudFoundryServiceTests.cs
@@ -1370,63 +1370,13 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
 
         [TestMethod]
         [TestCategory("DeployApp")]
-        public async Task DeployAppAsync_ReturnsFalseResult_WhenCfTargetOrgCommandFails()
-        {
-            const string fakeFailureExplanation = "junk";
-            var fakeCfCmdResponse = new DetailedResult(false, fakeFailureExplanation);
-
-            _mockCfCliService.Setup(mock =>
-                mock.TargetOrg(FakeOrg.OrgName))
-                    .Returns(fakeCfCmdResponse);
-
-            _mockFileLocatorService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
-
-            DetailedResult result = await _sut.DeployAppAsync(FakeCfInstance, FakeOrg, FakeSpace, FakeApp.AppName, _fakeProjectPath, _defaultFullFWFlag, stdOutCallback: null, stdErrCallback: null);
-
-            Assert.IsFalse(result.Succeeded);
-            Assert.IsTrue(result.Explanation.Contains(fakeFailureExplanation));
-        }
-        
-        [TestMethod]
-        [TestCategory("DeployApp")]
-        public async Task DeployAppAsync_ReturnsFalseResult_WhenCfTargetSpaceCommandFails()
-        {
-            const string fakeFailureExplanation = "junk";
-            var fakeCfCmdResponse = new DetailedResult(false, fakeFailureExplanation);
-
-            _mockCfCliService.Setup(mock =>
-                mock.TargetOrg(FakeOrg.OrgName))
-                    .Returns(_fakeSuccessDetailedResult);
-            
-            _mockCfCliService.Setup(mock =>
-                mock.TargetSpace(FakeSpace.SpaceName))
-                    .Returns(fakeCfCmdResponse);
-
-            _mockFileLocatorService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
-
-            DetailedResult result = await _sut.DeployAppAsync(FakeCfInstance, FakeOrg, FakeSpace, FakeApp.AppName, _fakeProjectPath, _defaultFullFWFlag, stdOutCallback: null, stdErrCallback: null);
-
-            Assert.IsFalse(result.Succeeded);
-            Assert.IsTrue(result.Explanation.Contains(fakeFailureExplanation));
-        }
-
-        [TestMethod]
-        [TestCategory("DeployApp")]
         public async Task DeployAppAsync_ReturnsFalseResult_WhenCfPushCommandFails()
         {
             const string fakeFailureExplanation = "junk";
             var fakeCfPushResponse = new DetailedResult(false, fakeFailureExplanation);
 
             _mockCfCliService.Setup(mock =>
-                mock.TargetOrg(FakeOrg.OrgName))
-                    .Returns(_fakeSuccessDetailedResult);
-
-            _mockCfCliService.Setup(mock =>
-                mock.TargetSpace(FakeSpace.SpaceName))
-                    .Returns(_fakeSuccessDetailedResult);
-
-            _mockCfCliService.Setup(mock =>
-                mock.PushAppAsync(FakeApp.AppName, null, null, _fakeProjectPath, null, null))
+                mock.PushAppAsync(FakeApp.AppName, FakeApp.ParentSpace.ParentOrg.OrgName, FakeApp.ParentSpace.SpaceName, null, null, _fakeProjectPath, null, null))
                     .ReturnsAsync(fakeCfPushResponse);
 
             _mockFileLocatorService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
@@ -1441,16 +1391,8 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
         [TestCategory("DeployApp")]
         public async Task DeployAppAsync_ReturnsTrueResult_WhenCfTargetAndPushCommandsSucceed()
         {
-            _mockCfCliService.Setup(mock => mock.
-                TargetOrg(FakeOrg.OrgName))
-                  .Returns(_fakeSuccessDetailedResult);
-
-            _mockCfCliService.Setup(mock => mock.
-                TargetSpace(FakeSpace.SpaceName))
-                  .Returns(_fakeSuccessDetailedResult);
-
             _mockCfCliService.Setup(mock =>
-                mock.PushAppAsync(FakeApp.AppName, null, null, _fakeProjectPath, null, null))
+                mock.PushAppAsync(FakeApp.AppName, FakeApp.ParentSpace.ParentOrg.OrgName, FakeApp.ParentSpace.SpaceName, null, null, _fakeProjectPath, null, null))
                     .ReturnsAsync(_fakeSuccessDetailedResult);
 
             _mockFileLocatorService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
@@ -1467,16 +1409,8 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
             string expectedBuildpackValue = "hwc_buildpack";
             string expectedStackValue = "windows";
 
-            _mockCfCliService.Setup(mock => mock.
-                TargetOrg(FakeOrg.OrgName))
-                  .Returns(_fakeSuccessDetailedResult);
-
-            _mockCfCliService.Setup(mock => mock.
-                TargetSpace(FakeSpace.SpaceName))
-                  .Returns(_fakeSuccessDetailedResult);
-
             _mockCfCliService.Setup(mock =>
-                mock.PushAppAsync(FakeApp.AppName, null, null, _fakeProjectPath, expectedBuildpackValue, expectedStackValue))
+                mock.PushAppAsync(FakeApp.AppName, FakeApp.ParentSpace.ParentOrg.OrgName, FakeApp.ParentSpace.SpaceName, null, null, _fakeProjectPath, expectedBuildpackValue, expectedStackValue))
                     .ReturnsAsync(_fakeSuccessDetailedResult);
 
             _mockFileLocatorService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);

--- a/src/Services/test/CloudFoundry/CloudFoundryServiceTests.cs
+++ b/src/Services/test/CloudFoundry/CloudFoundryServiceTests.cs
@@ -1377,7 +1377,7 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
 
             _mockCfCliService.Setup(mock =>
                 mock.TargetOrg(FakeOrg.OrgName))
-                    .ReturnsAsync(fakeCfCmdResponse);
+                    .Returns(fakeCfCmdResponse);
 
             _mockFileLocatorService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
 
@@ -1396,11 +1396,11 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
 
             _mockCfCliService.Setup(mock =>
                 mock.TargetOrg(FakeOrg.OrgName))
-                    .ReturnsAsync(_fakeSuccessDetailedResult);
+                    .Returns(_fakeSuccessDetailedResult);
             
             _mockCfCliService.Setup(mock =>
                 mock.TargetSpace(FakeSpace.SpaceName))
-                    .ReturnsAsync(fakeCfCmdResponse);
+                    .Returns(fakeCfCmdResponse);
 
             _mockFileLocatorService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
 
@@ -1419,11 +1419,11 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
 
             _mockCfCliService.Setup(mock =>
                 mock.TargetOrg(FakeOrg.OrgName))
-                    .ReturnsAsync(_fakeSuccessDetailedResult);
+                    .Returns(_fakeSuccessDetailedResult);
 
             _mockCfCliService.Setup(mock =>
                 mock.TargetSpace(FakeSpace.SpaceName))
-                    .ReturnsAsync(_fakeSuccessDetailedResult);
+                    .Returns(_fakeSuccessDetailedResult);
 
             _mockCfCliService.Setup(mock =>
                 mock.PushAppAsync(FakeApp.AppName, null, null, _fakeProjectPath, null, null))
@@ -1441,13 +1441,13 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
         [TestCategory("DeployApp")]
         public async Task DeployAppAsync_ReturnsTrueResult_WhenCfTargetAndPushCommandsSucceed()
         {
-            _mockCfCliService.Setup(mock =>
-                mock.TargetOrg(FakeOrg.OrgName))
-                    .ReturnsAsync(_fakeSuccessDetailedResult);
+            _mockCfCliService.Setup(mock => mock.
+                TargetOrg(FakeOrg.OrgName))
+                  .Returns(_fakeSuccessDetailedResult);
 
-            _mockCfCliService.Setup(mock =>
-                mock.TargetSpace(FakeSpace.SpaceName))
-                    .ReturnsAsync(_fakeSuccessDetailedResult);
+            _mockCfCliService.Setup(mock => mock.
+                TargetSpace(FakeSpace.SpaceName))
+                  .Returns(_fakeSuccessDetailedResult);
 
             _mockCfCliService.Setup(mock =>
                 mock.PushAppAsync(FakeApp.AppName, null, null, _fakeProjectPath, null, null))
@@ -1467,13 +1467,13 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
             string expectedBuildpackValue = "hwc_buildpack";
             string expectedStackValue = "windows";
 
-            _mockCfCliService.Setup(mock =>
-                mock.TargetOrg(FakeOrg.OrgName))
-                    .ReturnsAsync(_fakeSuccessDetailedResult);
+            _mockCfCliService.Setup(mock => mock.
+                TargetOrg(FakeOrg.OrgName))
+                  .Returns(_fakeSuccessDetailedResult);
 
-            _mockCfCliService.Setup(mock =>
-                mock.TargetSpace(FakeSpace.SpaceName))
-                    .ReturnsAsync(_fakeSuccessDetailedResult);
+            _mockCfCliService.Setup(mock => mock.
+                TargetSpace(FakeSpace.SpaceName))
+                  .Returns(_fakeSuccessDetailedResult);
 
             _mockCfCliService.Setup(mock =>
                 mock.PushAppAsync(FakeApp.AppName, null, null, _fakeProjectPath, expectedBuildpackValue, expectedStackValue))
@@ -1504,19 +1504,11 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
         [TestCategory("GetRecentLogs")]
         public async Task GetRecentLogs_ReturnsSuccessResult_WhenWrappedMethodSucceeds()
         {
-            _mockCfCliService.Setup(m => m.
-                TargetOrg(FakeApp.ParentSpace.ParentOrg.OrgName))
-                    .ReturnsAsync(_fakeSuccessDetailedResult);
-
-            _mockCfCliService.Setup(m => m.
-                TargetSpace(FakeApp.ParentSpace.SpaceName))
-                    .ReturnsAsync(_fakeSuccessDetailedResult);
-
             var logsStub = "These are fake app logs!\n[12:16:04] App took a nap.";
             var fakeLogsResult = new DetailedResult<string>(logsStub, true, null, _fakeSuccessCmdResult);
 
             _mockCfCliService.Setup(m => m
-                .GetRecentAppLogs(FakeApp.AppName))
+                .GetRecentAppLogs(FakeApp.AppName, FakeOrg.OrgName, FakeSpace.SpaceName))
                     .ReturnsAsync(fakeLogsResult);
 
             var result = await _sut.GetRecentLogs(FakeApp);
@@ -1531,20 +1523,12 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
         [TestCategory("GetRecentLogs")]
         public async Task GetRecentLogs_ReturnsFailedResult_WhenWrappedMethodFails()
         {
-            _mockCfCliService.Setup(m => m.
-                TargetOrg(FakeApp.ParentSpace.ParentOrg.OrgName))
-                    .ReturnsAsync(_fakeSuccessDetailedResult);
-
-            _mockCfCliService.Setup(m => m.
-                TargetSpace(FakeApp.ParentSpace.SpaceName))
-                    .ReturnsAsync(_fakeSuccessDetailedResult);
-
             string fakeLogs = null;
             var fakeErrorMsg = "something went wrong";
             var fakeLogsResult = new DetailedResult<string>(fakeLogs, false, fakeErrorMsg, _fakeFailureCmdResult);
 
             _mockCfCliService.Setup(m => m
-                .GetRecentAppLogs(FakeApp.AppName))
+                .GetRecentAppLogs(FakeApp.AppName, FakeOrg.OrgName, FakeSpace.SpaceName))
                     .ReturnsAsync(fakeLogsResult);
 
             var result = await _sut.GetRecentLogs(FakeApp);
@@ -1553,42 +1537,6 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
             Assert.AreEqual(result.Succeeded, fakeLogsResult.Succeeded);
             Assert.AreEqual(result.Explanation, fakeLogsResult.Explanation);
             Assert.AreEqual(result.CmdDetails, fakeLogsResult.CmdDetails);
-        }
-
-        [TestMethod]
-        [TestCategory("GetRecentLogs")]
-        public async Task GetRecentLogs_ReturnsFailedResult_WhenTargetOrgFails()
-        {
-            _mockCfCliService.Setup(m => m.
-                TargetOrg(FakeApp.ParentSpace.ParentOrg.OrgName))
-                    .ReturnsAsync(_fakeFailureDetailedResult);
-
-            var result = await _sut.GetRecentLogs(FakeApp);
-
-            Assert.IsNull(result.Content);
-            Assert.IsFalse(result.Succeeded);
-            Assert.AreEqual(result.Explanation, _fakeFailureDetailedResult.Explanation);
-            Assert.AreEqual(result.CmdDetails, _fakeFailureDetailedResult.CmdDetails);
-        }
-
-        [TestMethod]
-        [TestCategory("GetRecentLogs")]
-        public async Task GetRecentLogs_ReturnsFailedResult_WhenTargetSpaceFails()
-        {
-            _mockCfCliService.Setup(m => m.
-                TargetOrg(FakeApp.ParentSpace.ParentOrg.OrgName))
-                    .ReturnsAsync(_fakeSuccessDetailedResult);
-
-            _mockCfCliService.Setup(m => m.
-                TargetSpace(FakeApp.ParentSpace.SpaceName))
-                    .ReturnsAsync(_fakeFailureDetailedResult);
-
-            var result = await _sut.GetRecentLogs(FakeApp);
-
-            Assert.IsNull(result.Content);
-            Assert.IsFalse(result.Succeeded);
-            Assert.AreEqual(result.Explanation, _fakeFailureDetailedResult.Explanation);
-            Assert.AreEqual(result.CmdDetails, _fakeFailureDetailedResult.CmdDetails);
         }
     }
 }


### PR DESCRIPTION
Move onus of targeting orgs & spaces to the CfCliService itself for these methods:

1. PushAppAsync
2. GetRecentAppLogs

Now that the org/space targeting happens in the same method that issues the push/logs request, we're able to add a lock (corresponding to file access to the CF CLI `config.json` file) around these operations such that the targeting happens atomically with the actual CF request (i.e. `push` or `logs`)