### PR TITLE
Print debug msg when PropChanged event handler null [#39]

### DIFF
--- a/src/ViewModels/src/AbstractViewModel.cs
+++ b/src/ViewModels/src/AbstractViewModel.cs
@@ -34,11 +34,11 @@ namespace Tanzu.Toolkit.ViewModels
         public ICloudFoundryService CloudFoundryService { get; }
 
         public IViewLocatorService ViewLocatorService { get; }
-        
+
         public IThreadingService ThreadingService { get; }
 
         public IUiDispatcherService UiDispatcherService { get; }
-        
+
         public IDialogService DialogService { get; }
 
         public ILogger Logger { get; }
@@ -64,6 +64,10 @@ namespace Tanzu.Toolkit.ViewModels
             if (handler != null)
             {
                 handler(this, new PropertyChangedEventArgs(propertyName));
+            }
+            else
+            {
+                Logger.Debug($"Detected null PropertyChanged handler; is there a subscriber for the event '{propertyName}'?");
             }
         }
     }

--- a/src/WpfViews/test/ViewTestSupport.cs
+++ b/src/WpfViews/test/ViewTestSupport.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using Serilog;
 using Tanzu.Toolkit.Services;
 using Tanzu.Toolkit.Services.CloudFoundry;
 using Tanzu.Toolkit.Services.Dialog;
@@ -24,6 +25,7 @@ namespace Tanzu.Toolkit.WpfViews.Tests
         protected Mock<IDialogService> mockDialogService;
         protected Mock<IViewLocatorService> mockViewLocatorService;
         protected Mock<ILoggingService> mockLoggingService;
+        protected Mock<ILogger> mockLogger;
         protected Mock<IUiDispatcherService> mockUiDispatcherService;
         protected Mock<IThreadingService> mockThreadingService;
         protected Mock<IThemeService> mockThemeService;
@@ -45,6 +47,9 @@ namespace Tanzu.Toolkit.WpfViews.Tests
             mockThemeService = new Mock<IThemeService>();
             mockViewService = new Mock<IViewService>();
             mockTasExplorerViewModel = new Mock<ITasExplorerViewModel>();
+
+            mockLogger = new Mock<ILogger>();
+            mockLoggingService.SetupGet(m => m.Logger).Returns(mockLogger.Object);
 
             services.AddSingleton(mockCloudFoundryService.Object);
             services.AddSingleton(mockErrorDialogService.Object);


### PR DESCRIPTION
- also add mockLogger to ViewTestSupport to prevent failures due to System.NullReferenceException