### PR TITLE
Buildpack selection #165

### DIFF
--- a/src/CloudFoundryApiClient/src/ICfApiClient.cs
+++ b/src/CloudFoundryApiClient/src/ICfApiClient.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Tanzu.Toolkit.CloudFoundryApiClient.Models;
 using Tanzu.Toolkit.CloudFoundryApiClient.Models.AppsResponse;
 using Tanzu.Toolkit.CloudFoundryApiClient.Models.OrgsResponse;
 using Tanzu.Toolkit.CloudFoundryApiClient.Models.SpacesResponse;
@@ -25,5 +26,6 @@ namespace Tanzu.Toolkit.CloudFoundryApiClient
         Task<bool> StartAppWithGuid(string cfTarget, string accessToken, string appGuid);
 
         Task<bool> DeleteAppWithGuid(string cfTarget, string accessToken, string appGuid);
+        Task<List<Buildpack>> ListBuildpacks(string cfApiAddress, string accessToken);
     }
 }

--- a/src/CloudFoundryApiClient/src/Models/BuildpacksResponse.cs
+++ b/src/CloudFoundryApiClient/src/Models/BuildpacksResponse.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace Tanzu.Toolkit.CloudFoundryApiClient.Models
+{
+    public class BuildpacksResponse
+    {
+        [JsonProperty("pagination")]
+        public Pagination Pagination { get; set; }
+
+        [JsonProperty("resources")]
+        public Buildpack[] Buildpacks { get; set; }
+    }
+
+    public class Buildpack
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        [JsonProperty("stack")]
+        public string Stack { get; set; }
+    }
+}

--- a/src/CloudFoundryApiClient/test/CfApiClientTestSupport.cs
+++ b/src/CloudFoundryApiClient/test/CfApiClientTestSupport.cs
@@ -90,6 +90,27 @@ namespace Tanzu.Toolkit.CloudFoundryApiClient.Tests
             totalResults: 125,
             totalPages: 3,
             resultsPerPage: 50));
+
+        internal static readonly string _fakeBuildpacksJsonResponsePage1 = JsonConvert.SerializeObject(new FakeBuildpacksResponse(
+            apiAddress: _fakeCfApiAddress,
+            pageNum: 1,
+            totalResults: 125,
+            totalPages: 3,
+            resultsPerPage: 50));
+
+        internal static readonly string _fakeBuildpacksJsonResponsePage2 = JsonConvert.SerializeObject(new FakeBuildpacksResponse(
+            apiAddress: _fakeCfApiAddress,
+            pageNum: 2,
+            totalResults: 125,
+            totalPages: 3,
+            resultsPerPage: 50));
+
+        internal static readonly string _fakeBuildpacksJsonResponsePage3 = JsonConvert.SerializeObject(new FakeBuildpacksResponse(
+            apiAddress: _fakeCfApiAddress,
+            pageNum: 3,
+            totalResults: 125,
+            totalPages: 3,
+            resultsPerPage: 50));
     }
 
     internal class FakeBasicInfoResponse : BasicInfoResponse
@@ -270,6 +291,63 @@ namespace Tanzu.Toolkit.CloudFoundryApiClient.Tests
             }
 
             Apps = apps;
+        }
+    }
+
+    internal class FakeBuildpacksResponse : BuildpacksResponse
+    {
+        public FakeBuildpacksResponse(string apiAddress, int pageNum, int totalResults, int totalPages, int resultsPerPage)
+        {
+            bool isFirstPage = pageNum == 1;
+            bool isLastPage = pageNum == totalPages;
+
+            var firstHref = new HypertextReference() { Href = $"{apiAddress}{CfApiClient.ListBuildpacksPath}?page=1&per_page={resultsPerPage}" };
+            var lastHref = new HypertextReference() { Href = $"{apiAddress}{CfApiClient.ListBuildpacksPath}?page={totalPages}&per_page={resultsPerPage}" };
+            var nextHref = isLastPage ? null : new HypertextReference() { Href = $"{apiAddress}{CfApiClient.ListBuildpacksPath}?page={pageNum + 1}&per_page={resultsPerPage}" };
+            var previousHref = isFirstPage ? null : new HypertextReference() { Href = $"{apiAddress}{CfApiClient.ListBuildpacksPath}?page={pageNum - 1}&per_page={resultsPerPage}" };
+
+            Pagination = new Pagination
+            {
+                Total_results = totalResults,
+                Total_pages = totalPages,
+                First = firstHref,
+                Last = lastHref,
+                Next = nextHref,
+                Previous = previousHref,
+            };
+
+            Buildpack[] buildpacks;
+
+            var numPreviousResults = (pageNum - 1) * resultsPerPage;
+            
+            if (isLastPage)
+            {
+                int numResourcesInLastPage = totalResults % resultsPerPage;
+                buildpacks = new Buildpack[numResourcesInLastPage];
+
+                for (int i = 0; i < numResourcesInLastPage; i++)
+                {
+                    buildpacks[i] = new Buildpack
+                    {
+                        Name = $"fakeBuildpack{i / 3 + 1 + numPreviousResults}",
+                        Stack = $"fakeStack{i % 3 + 1 + numPreviousResults}",
+                    };
+                }
+            }
+            else
+            {
+                buildpacks = new Buildpack[resultsPerPage];
+
+                for (int i = 0; i < resultsPerPage; i++)
+                {
+                    buildpacks[i] = new Buildpack
+                    {
+                        Name = $"fakeBuildpack{i / 3 + 1 + numPreviousResults}",
+                        Stack = $"fakeStack{i % 3 + 1 + numPreviousResults}",
+                    };
+                }
+            }
+            Buildpacks = buildpacks;
         }
     }
 }

--- a/src/CloudFoundryApiClient/test/CfApiClientTestSupport.cs
+++ b/src/CloudFoundryApiClient/test/CfApiClientTestSupport.cs
@@ -319,7 +319,18 @@ namespace Tanzu.Toolkit.CloudFoundryApiClient.Tests
             Buildpack[] buildpacks;
 
             var numPreviousResults = (pageNum - 1) * resultsPerPage;
-            
+            int numStackTypesPerBuildpack = 3;
+            /* INTENTION: assign Buildpacks prop to contain a list like this:
+             * bp.Name = fakeBuildpack1, bp.Stack = fakeStack1
+             * bp.Name = fakeBuildpack1, bp.Stack = fakeStack2
+             * bp.Name = fakeBuildpack1, bp.Stack = fakeStack3
+             * bp.Name = fakeBuildpack2, bp.Stack = fakeStack1
+             * bp.Name = fakeBuildpack2, bp.Stack = fakeStack2
+             * bp.Name = fakeBuildpack2, bp.Stack = fakeStack3
+             * bp.Name = fakeBuildpack3, bp.Stack = fakeStack1
+             * ...
+             */
+
             if (isLastPage)
             {
                 int numResourcesInLastPage = totalResults % resultsPerPage;
@@ -327,10 +338,13 @@ namespace Tanzu.Toolkit.CloudFoundryApiClient.Tests
 
                 for (int i = 0; i < numResourcesInLastPage; i++)
                 {
+                    int buildpackId = i / numStackTypesPerBuildpack + 1 + numPreviousResults;
+                    int stackTypeId = i % numStackTypesPerBuildpack + 1 + numPreviousResults;
+
                     buildpacks[i] = new Buildpack
                     {
-                        Name = $"fakeBuildpack{i / 3 + 1 + numPreviousResults}",
-                        Stack = $"fakeStack{i % 3 + 1 + numPreviousResults}",
+                        Name = $"fakeBuildpack{buildpackId}",
+                        Stack = $"fakeStack{stackTypeId}",
                     };
                 }
             }
@@ -340,13 +354,17 @@ namespace Tanzu.Toolkit.CloudFoundryApiClient.Tests
 
                 for (int i = 0; i < resultsPerPage; i++)
                 {
+                    int buildpackId = i / numStackTypesPerBuildpack + 1 + numPreviousResults;
+                    int stackTypeId = i % numStackTypesPerBuildpack + 1 + numPreviousResults;
+
                     buildpacks[i] = new Buildpack
                     {
-                        Name = $"fakeBuildpack{i / 3 + 1 + numPreviousResults}",
-                        Stack = $"fakeStack{i % 3 + 1 + numPreviousResults}",
+                        Name = $"fakeBuildpack{buildpackId}",
+                        Stack = $"fakeStack{stackTypeId}",
                     };
                 }
             }
+
             Buildpacks = buildpacks;
         }
     }

--- a/src/Models/src/AppManifest.cs
+++ b/src/Models/src/AppManifest.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+
+namespace Tanzu.Toolkit.Models
+{
+    public class AppManifest
+    {
+        public int Version { get; set; }
+        public List<AppConfig> Applications { get; set; }
+    }
+
+    public class AppConfig
+    {
+        public List<string> Buildpacks { get; set; }
+        public string Command { get; set; }
+        public string DiskQuota { get; set; }
+        public DockerConfig Docker { get; set; }
+        public Dictionary<string, string> Env { get; set; }
+        public string HealthCheckHttpEndpoint { get; set; }
+        public string HealthCheckType { get; set; }
+        public int Instances { get; set; }
+        public string Memory { get; set; }
+        public MetadataConfig Metadata { get; set; }
+        public string Name { get; set; }
+        public bool NoRoute { get; set; }
+        public string Path { get; set; }
+        public List<ProcessConfig> Processes { get; set; }
+        public bool RandomRoute { get; set; }
+        public bool DefaultRoute { get; set; }
+        public List<RouteConfig> Routes { get; set; }
+        public List<ServiceConfig> Services { get; set; }
+        public List<SidecarConfig> Sidecars { get; set; }
+        public string Stack { get; set; }
+    }
+
+    public class DockerConfig
+    {
+        public string Image { get; set; }
+        public string Username { get; set; }
+    }
+
+    public class MetadataConfig
+    {
+        public Dictionary<string, string> Annotations { get; set; }
+        public Dictionary<string, string> Labels { get; set; }
+    }
+
+    public class ProcessConfig
+    {
+        public string Type { get; set; }
+        public string Command { get; set; }
+        public string DiskQuota { get; set; }
+        public string HealthCheckHttpEndpoint { get; set; }
+        public int HealthCheckInvocationTimeout { get; set; }
+        public string HealthCheckType { get; set; }
+        public int Instances { get; set; }
+        public string Memory { get; set; }
+        public int Timeout { get; set; }
+    }
+
+    public class RouteConfig
+    {
+        public string Route { get; set; }
+        public string Protocol { get; set; }
+    }
+
+    public class ServiceConfig
+    {
+        public string Name { get; set; }
+        public string BindingName { get; set; }
+        public Dictionary<object, object> Parameters { get; set; }
+    }
+
+    public class SidecarConfig
+    {
+        public string Name { get; set; }
+        public string Command { get; set; }
+        public List<string> ProcessTypes { get; set; }
+        public string Memory { get; set; }
+    }
+}

--- a/src/Models/src/AppManifest.cs
+++ b/src/Models/src/AppManifest.cs
@@ -27,7 +27,7 @@ namespace Tanzu.Toolkit.Models
         public bool RandomRoute { get; set; }
         public bool DefaultRoute { get; set; }
         public List<RouteConfig> Routes { get; set; }
-        public List<ServiceConfig> Services { get; set; }
+        public List<string> Services { get; set; }
         public List<SidecarConfig> Sidecars { get; set; }
         public string Stack { get; set; }
     }

--- a/src/Services/src/CfAppManifestNamingConvention.cs
+++ b/src/Services/src/CfAppManifestNamingConvention.cs
@@ -1,0 +1,27 @@
+﻿using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Tanzu.Toolkit.Services
+{
+    public class CfAppManifestNamingConvention : INamingConvention
+    {
+        public string Apply(string value)
+        {
+            var hyphenatedString = HyphenatedNamingConvention.Instance.Apply(value);
+
+            switch (hyphenatedString)
+            {
+                case "disk-quota":
+                    return "disk_quota";
+                case "binding-name":
+                    return "binding_name";
+                case "process-types":
+                    return "process_types";
+                default:
+                    return hyphenatedString;
+            }
+        }
+
+        public static readonly INamingConvention Instance = new CfAppManifestNamingConvention();
+    }
+}

--- a/src/Services/src/CfCli/CfCliService.cs
+++ b/src/Services/src/CfCli/CfCliService.cs
@@ -9,7 +9,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Tanzu.Toolkit.Services.CommandProcess;
-using Tanzu.Toolkit.Services.FileLocator;
+using Tanzu.Toolkit.Services.File;
 using Tanzu.Toolkit.Services.Logging;
 using static Tanzu.Toolkit.Services.OutputHandler.OutputHandler;
 
@@ -38,7 +38,7 @@ namespace Tanzu.Toolkit.Services.CfCli
         internal const string _deleteAppCmd = "delete -f"; // -f avoids confirmation prompt
         internal const string _invalidRefreshTokenError = "The token expired, was revoked, or the token ID is incorrect. Please log back in to re-authenticate.";
 
-        private readonly IFileLocatorService _fileLocatorService;
+        private readonly IFileService _fileService;
         private readonly ILogger _logger;
 
         private object _cfEnvironmentLock = new object();
@@ -54,7 +54,7 @@ namespace Tanzu.Toolkit.Services.CfCli
         {
             ConfigFilePath = configFilePath;
             Services = services;
-            _fileLocatorService = services.GetRequiredService<IFileLocatorService>();
+            _fileService = services.GetRequiredService<IFileService>();
             var logSvc = services.GetRequiredService<ILoggingService>();
             _logger = logSvc.Logger;
         }
@@ -414,7 +414,7 @@ namespace Tanzu.Toolkit.Services.CfCli
         /// <returns>A <see cref="DetailedResult"/> containing the results of the CF command.</returns>
         public DetailedResult ExecuteCfCliCommand(string arguments, string workingDir = null)
         {
-            string pathToCfExe = _fileLocatorService.FullPathToCfExe;
+            string pathToCfExe = _fileService.FullPathToCfExe;
             if (string.IsNullOrEmpty(pathToCfExe))
             {
                 return new DetailedResult(false, _cfExePathErrorMsg);
@@ -460,7 +460,7 @@ namespace Tanzu.Toolkit.Services.CfCli
         /// <returns>An awaitable <see cref="Task"/> which will return a <see cref="DetailedResult"/> containing the results of the CF command.</returns>
         internal async Task<DetailedResult> RunCfCommandAsync(string arguments, StdOutDelegate stdOutCallback = null, StdErrDelegate stdErrCallback = null, string workingDir = null)
         {
-            string pathToCfExe = _fileLocatorService.FullPathToCfExe;
+            string pathToCfExe = _fileService.FullPathToCfExe;
             if (string.IsNullOrEmpty(pathToCfExe))
             {
                 return new DetailedResult(false, $"Unable to locate cf.exe.");

--- a/src/Services/src/CfCli/CfCliService.cs
+++ b/src/Services/src/CfCli/CfCliService.cs
@@ -303,40 +303,15 @@ namespace Tanzu.Toolkit.Services.CfCli
             return result;
         }
 
-        /// <summary>
-        /// Invokes `cf push` with the specified app name. Assumes the proper org & space have already been targeted.
-        /// </summary>
-        /// <param name="appName"></param>
-        /// <param name="stdOutCallback"></param>
-        /// <param name="stdErrCallback"></param>
-        /// <param name="appDir"></param>
-        public async Task<DetailedResult> PushAppAsync(string appName, string orgName, string spaceName, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string appDirPath, string buildpack = null, string stack = null, string startCommand = null, string manifestPath = null)
+        public async Task<DetailedResult> PushAppAsync(string manifestPath, string appDirPath, string orgName, string spaceName, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback)
         {
-            string args = $"push \"{appName}\"";
+            string args = $"push -f \"{manifestPath}\"";
 
-            if (buildpack != null)
+            if (!_fileService.FileExists(manifestPath))
             {
-                args += $" -b {buildpack}";
-            }
-
-            if (stack != null)
-            {
-                args += $" -s {stack}";
-            }
-
-            if (startCommand != null)
-            {
-                args += $" -c \"{startCommand}\"";
-            }
-
-            if (manifestPath != null)
-            {
-                args += $" -f \"{manifestPath}\"";
-            }
-
-            if (appDirPath != null)
-            {
-                args += $" -p \"{appDirPath}\"";
+                string msg = $"Unable to deploy app; no manifest file found at '{manifestPath}'";
+                _logger.Error(msg);
+                return new DetailedResult(false, explanation: msg);
             }
 
             Task<DetailedResult> deployTask;
@@ -345,7 +320,7 @@ namespace Tanzu.Toolkit.Services.CfCli
                 var targetOrgResult = TargetOrg(orgName);
                 if (!targetOrgResult.Succeeded)
                 {
-                    string msg = $"Unable to deploy app '{appName}'; failed to target org '{orgName}'.\n{targetOrgResult.Explanation}";
+                    string msg = $"Unable to deploy app from '{manifestPath}'; failed to target org '{orgName}'.\n{targetOrgResult.Explanation}";
                     _logger.Error(msg);
                     return new DetailedResult(false, explanation: msg, targetOrgResult.CmdResult);
                 }
@@ -353,7 +328,7 @@ namespace Tanzu.Toolkit.Services.CfCli
                 var targetSpaceResult = TargetSpace(spaceName);
                 if (!targetSpaceResult.Succeeded)
                 {
-                    string msg = $"Unable to deploy app '{appName}'; failed to target space '{spaceName}'.\n{targetSpaceResult.Explanation}";
+                    string msg = $"Unable to deploy app from '{manifestPath}'; failed to target space '{spaceName}'.\n{targetSpaceResult.Explanation}";
                     _logger.Error(msg);
                     return new DetailedResult(false, explanation: msg, targetSpaceResult.CmdResult);
                 }
@@ -367,6 +342,7 @@ namespace Tanzu.Toolkit.Services.CfCli
 
             return deployResult;
         }
+
 
         public async Task<DetailedResult<string>> GetRecentAppLogs(string appName, string orgName, string spaceName)
         {

--- a/src/Services/src/CfCli/ICfCliService.cs
+++ b/src/Services/src/CfCli/ICfCliService.cs
@@ -16,9 +16,9 @@ namespace Tanzu.Toolkit.Services.CfCli
         Task<DetailedResult> StopAppByNameAsync(string appName);
         Task<DetailedResult> StartAppByNameAsync(string appName);
         Task<DetailedResult> DeleteAppByNameAsync(string appName, bool removeMappedRoutes = true);
-        Task<DetailedResult> PushAppAsync(string appName, string orgName, string spaceName, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string appDirPath, string buildpack = null, string stack = null, string startCommand = null, string manifestPath = null);
         Task<Version> GetApiVersion();
         Task<DetailedResult<string>> GetRecentAppLogs(string appName, string orgName, string spaceName);
         void ClearCachedAccessToken();
+        Task<DetailedResult> PushAppAsync(string manifestPath, string appDirPath, string orgName, string spaceName, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback);
     }
 }

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -768,41 +768,16 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
             };
         }
 
-        public async Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string pathToDeploymentDirectory, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string stack, bool binaryDeployment, string projectName, string manifestPath = null, string buildpack = null)
+        public async Task<DetailedResult> DeployAppAsync(string appName, string manifestPath, string pathToDeploymentDirectory, CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback)
         {
             if (!_fileService.DirContainsFiles(pathToDeploymentDirectory))
             {
                 return new DetailedResult(false, EmptyOutputDirMessage);
             }
 
-            string startCommand = null;
-
-            if (fullFrameworkDeployment)
-            {
-                buildpack = "hwc_buildpack";
-                stack = "windows";
-            }
-
             DetailedResult cfPushResult;
             try
             {
-                if (binaryDeployment)
-                {
-                    buildpack = "binary_buildpack";
-                    startCommand = $"cmd /c .\\{projectName} --urls=http://*:%PORT%";
-
-                    if (fullFrameworkDeployment)
-                    {
-                        startCommand = $"cmd /c .\\{projectName} --server.urls=http://*:%PORT%";
-                    }
-
-                    if (stack == "cflinuxfs3")
-                    {
-                        buildpack = "dotnet_core_buildpack";
-                        startCommand = null;
-                    }
-                }
-
                 cfPushResult = await _cfCliService.PushAppAsync(manifestPath, pathToDeploymentDirectory, targetOrg.OrgName, targetSpace.SpaceName, stdOutCallback, stdErrCallback);
             }
             catch (InvalidRefreshTokenException)

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -803,7 +803,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
                     }
                 }
 
-                cfPushResult = await _cfCliService.PushAppAsync(appName, targetOrg.OrgName, targetSpace.SpaceName, stdOutCallback, stdErrCallback, pathToDeploymentDirectory, buildpack, stack, startCommand, manifestPath);
+                cfPushResult = await _cfCliService.PushAppAsync(manifestPath, pathToDeploymentDirectory, targetOrg.OrgName, targetSpace.SpaceName, stdOutCallback, stdErrCallback);
             }
             catch (InvalidRefreshTokenException)
             {

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -687,14 +687,13 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
             };
         }
 
-        public async Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string pathToDeploymentDirectory, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string stack, bool binaryDeployment, string projectName, string manifestPath = null)
+        public async Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string pathToDeploymentDirectory, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string stack, bool binaryDeployment, string projectName, string manifestPath = null, string buildpack = null)
         {
             if (!_fileLocatorService.DirContainsFiles(pathToDeploymentDirectory))
             {
                 return new DetailedResult(false, EmptyOutputDirMessage);
             }
 
-            string buildpack = null;
             string startCommand = null;
 
             if (fullFrameworkDeployment)

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -14,6 +14,8 @@ using Tanzu.Toolkit.Services.CfCli;
 using Tanzu.Toolkit.Services.ErrorDialog;
 using Tanzu.Toolkit.Services.File;
 using Tanzu.Toolkit.Services.Logging;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
 using static Tanzu.Toolkit.Services.OutputHandler.OutputHandler;
 
 namespace Tanzu.Toolkit.Services.CloudFoundry
@@ -849,6 +851,34 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
             }
 
             return logsResult;
+        }
+
+        public DetailedResult CreateManifestFile(string location, AppManifest manifest)
+        {
+            try
+            {
+                var serializer = new SerializerBuilder()
+                    .WithNamingConvention(CfAppManifestNamingConvention.Instance)
+                    .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+                    .Build();
+
+                string ymlContents = serializer.Serialize(manifest);
+
+                _fileService.WriteTextToFile(location, "---\n" + ymlContents);
+
+                return new DetailedResult
+                {
+                    Succeeded = true
+                };
+            }
+            catch (Exception ex)
+            {
+                return new DetailedResult
+                {
+                    Succeeded = false,
+                    Explanation = ex.Message,
+                };
+            }
         }
 
         private void FormatExceptionMessage(Exception ex, List<string> message)

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -12,7 +12,7 @@ using Tanzu.Toolkit.CloudFoundryApiClient.Models.SpacesResponse;
 using Tanzu.Toolkit.Models;
 using Tanzu.Toolkit.Services.CfCli;
 using Tanzu.Toolkit.Services.ErrorDialog;
-using Tanzu.Toolkit.Services.FileLocator;
+using Tanzu.Toolkit.Services.File;
 using Tanzu.Toolkit.Services.Logging;
 using static Tanzu.Toolkit.Services.OutputHandler.OutputHandler;
 
@@ -27,7 +27,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
 
         private readonly ICfApiClient _cfApiClient;
         private readonly ICfCliService _cfCliService;
-        private readonly IFileLocatorService _fileLocatorService;
+        private readonly IFileService _fileService;
         private readonly IErrorDialog _dialogService;
         private readonly ILogger _logger;
 
@@ -35,7 +35,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         {
             _cfApiClient = services.GetRequiredService<ICfApiClient>();
             _cfCliService = services.GetRequiredService<ICfCliService>();
-            _fileLocatorService = services.GetRequiredService<IFileLocatorService>();
+            _fileService = services.GetRequiredService<IFileService>();
             _dialogService = services.GetRequiredService<IErrorDialog>();
 
             var logSvc = services.GetRequiredService<ILoggingService>();
@@ -769,7 +769,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
 
         public async Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string pathToDeploymentDirectory, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string stack, bool binaryDeployment, string projectName, string manifestPath = null, string buildpack = null)
         {
-            if (!_fileLocatorService.DirContainsFiles(pathToDeploymentDirectory))
+            if (!_fileService.DirContainsFiles(pathToDeploymentDirectory))
             {
                 return new DetailedResult(false, EmptyOutputDirMessage);
             }
@@ -876,7 +876,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
             Version apiVersion = await _cfCliService.GetApiVersion();
             if (apiVersion == null)
             {
-                _fileLocatorService.CliVersion = 7;
+                _fileService.CliVersion = 7;
                 _dialogService.DisplayErrorDialog(CcApiVersionUndetectableErrTitle, CcApiVersionUndetectableErrMsg);
             }
             else
@@ -886,7 +886,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
                     case 2:
                         if (apiVersion < new Version("2.128.0"))
                         {
-                            _fileLocatorService.CliVersion = 6;
+                            _fileService.CliVersion = 6;
 
                             string errorTitle = "API version not supported";
                             string errorMsg = "Detected a Cloud Controller API version lower than the minimum supported version (2.128.0); some features of this extension may not work as expected for the given instance.";
@@ -896,11 +896,11 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
                         }
                         else if (apiVersion < new Version("2.150.0"))
                         {
-                            _fileLocatorService.CliVersion = 6;
+                            _fileService.CliVersion = 6;
                         }
                         else
                         {
-                            _fileLocatorService.CliVersion = 7;
+                            _fileService.CliVersion = 7;
                         }
 
                         break;
@@ -908,7 +908,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
                     case 3:
                         if (apiVersion < new Version("3.63.0"))
                         {
-                            _fileLocatorService.CliVersion = 6;
+                            _fileService.CliVersion = 6;
 
                             string errorTitle = "API version not supported";
                             string errorMsg = "Detected a Cloud Controller API version lower than the minimum supported version (3.63.0); some features of this extension may not work as expected for the given instance.";
@@ -918,17 +918,17 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
                         }
                         else if (apiVersion < new Version("3.85.0"))
                         {
-                            _fileLocatorService.CliVersion = 6;
+                            _fileService.CliVersion = 6;
                         }
                         else
                         {
-                            _fileLocatorService.CliVersion = 7;
+                            _fileService.CliVersion = 7;
                         }
 
                         break;
 
                     default:
-                        _fileLocatorService.CliVersion = 7;
+                        _fileService.CliVersion = 7;
                         _logger.Information("Detected an unexpected Cloud Controller API version: {apiVersion}. CLI version has been set to 7 by default.", apiVersion);
 
                         break;

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -15,7 +15,6 @@ using Tanzu.Toolkit.Services.ErrorDialog;
 using Tanzu.Toolkit.Services.File;
 using Tanzu.Toolkit.Services.Logging;
 using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 using static Tanzu.Toolkit.Services.OutputHandler.OutputHandler;
 
 namespace Tanzu.Toolkit.Services.CloudFoundry
@@ -876,6 +875,45 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
                 return new DetailedResult
                 {
                     Succeeded = false,
+                    Explanation = ex.Message,
+                };
+            }
+        }
+
+        public DetailedResult<AppManifest> ParseManifestFile(string pathToManifestFile)
+        {
+            if (!_fileService.FileExists(pathToManifestFile))
+            {
+                return new DetailedResult<AppManifest>
+                {
+                    Succeeded = false,
+                    Content = null,
+                    Explanation = $"No file exists at {pathToManifestFile}",
+                };
+            }
+
+            try
+            {
+                string manifestContents = _fileService.ReadFileContents(pathToManifestFile);
+
+                var deserializer = new DeserializerBuilder()
+                    .WithNamingConvention(CfAppManifestNamingConvention.Instance)
+                    .Build();
+
+                var manifest = deserializer.Deserialize<AppManifest>(manifestContents);
+
+                return new DetailedResult<AppManifest>
+                {
+                    Succeeded = true,
+                    Content = manifest,
+                };
+            }
+            catch (Exception ex)
+            {
+                return new DetailedResult<AppManifest>
+                {
+                    Succeeded = false,
+                    Content = null,
                     Explanation = ex.Message,
                 };
             }

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -409,7 +409,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
             };
         }
 
-        public async Task<DetailedResult<List<string>>> GetBuildpackNamesAsync(string apiAddress, int retryAmount = 1)
+        public async Task<DetailedResult<List<string>>> GetUniqueBuildpackNamesAsync(string apiAddress, int retryAmount = 1)
         {
             string accessToken;
             try
@@ -450,10 +450,10 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
             {
                 if (retryAmount > 0)
                 {
-                    _logger.Information("GetBuildpackNamesAsync caught an exception when trying to retrieve buildpacks: {originalException}. About to clear the cached access token & try again ({retryAmount} retry attempts remaining).", originalException.Message, retryAmount);
+                    _logger.Information("GetUniqueBuildpackNamesAsync caught an exception when trying to retrieve buildpacks: {originalException}. About to clear the cached access token & try again ({retryAmount} retry attempts remaining).", originalException.Message, retryAmount);
                     _cfCliService.ClearCachedAccessToken();
                     retryAmount -= 1;
-                    return await GetBuildpackNamesAsync(apiAddress, retryAmount);
+                    return await GetUniqueBuildpackNamesAsync(apiAddress, retryAmount);
                 }
                 else
                 {
@@ -473,9 +473,9 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
             {
                 if (string.IsNullOrWhiteSpace(buildpack.Name))
                 {
-                    _logger.Error("CloudFoundryService.GetBuildpackNamesAsync encountered a buildpack without a name; omitting it from the returned list of buildpacks.");
+                    _logger.Error("CloudFoundryService.GetUniqueBuildpackNamesAsync encountered a buildpack without a name; omitting it from the returned list of buildpacks.");
                 }
-                else
+                else if (!buildpackNames.Contains(buildpack.Name))
                 {
                     buildpackNames.Add(buildpack.Name);
                 }
@@ -795,7 +795,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
                         startCommand = $"cmd /c .\\{projectName} --server.urls=http://*:%PORT%";
                     }
 
-                    if (stack == "cflinuxfs3") 
+                    if (stack == "cflinuxfs3")
                     {
                         buildpack = "dotnet_core_buildpack";
                         startCommand = null;

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -853,7 +853,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
             {
                 var serializer = new SerializerBuilder()
                     .WithNamingConvention(CfAppManifestNamingConvention.Instance)
-                    .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+                    .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
                     .Build();
 
                 string ymlContents = serializer.Serialize(manifest);

--- a/src/Services/src/CloudFoundry/ICloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/ICloudFoundryService.cs
@@ -15,10 +15,10 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         Task<DetailedResult> StopAppAsync(CloudFoundryApp app, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult> StartAppAsync(CloudFoundryApp app, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult> DeleteAppAsync(CloudFoundryApp app, bool skipSsl = true, bool removeRoutes = true, int retryAmount = 1);
-        Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string pathToDeploymentDirectory, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string stack, bool binaryDeployment, string projectName, string manifestPath = null, string buildpack = null);
         Task<DetailedResult<string>> GetRecentLogs(CloudFoundryApp app);
         Task<DetailedResult<List<string>>> GetUniqueBuildpackNamesAsync(string apiAddress, int retryAmount = 1);
         DetailedResult CreateManifestFile(string location, AppManifest manifest);
         DetailedResult<AppManifest> ParseManifestFile(string pathToManifestFile);
+        Task<DetailedResult> DeployAppAsync(string appName, string manifestPath, string pathToDeploymentDirectory, CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback);
     }
 }

--- a/src/Services/src/CloudFoundry/ICloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/ICloudFoundryService.cs
@@ -15,7 +15,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         Task<DetailedResult> StopAppAsync(CloudFoundryApp app, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult> StartAppAsync(CloudFoundryApp app, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult> DeleteAppAsync(CloudFoundryApp app, bool skipSsl = true, bool removeRoutes = true, int retryAmount = 1);
-        Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string pathToDeploymentDirectory, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string stack, bool binaryDeployment, string projectName, string manifestPath = null);
+        Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string pathToDeploymentDirectory, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string stack, bool binaryDeployment, string projectName, string manifestPath = null, string buildpack = null);
         Task<DetailedResult<string>> GetRecentLogs(CloudFoundryApp app);
     }
 }

--- a/src/Services/src/CloudFoundry/ICloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/ICloudFoundryService.cs
@@ -19,5 +19,6 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         Task<DetailedResult<string>> GetRecentLogs(CloudFoundryApp app);
         Task<DetailedResult<List<string>>> GetUniqueBuildpackNamesAsync(string apiAddress, int retryAmount = 1);
         DetailedResult CreateManifestFile(string location, AppManifest manifest);
+        DetailedResult<AppManifest> ParseManifestFile(string pathToManifestFile);
     }
 }

--- a/src/Services/src/CloudFoundry/ICloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/ICloudFoundryService.cs
@@ -18,5 +18,6 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string pathToDeploymentDirectory, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string stack, bool binaryDeployment, string projectName, string manifestPath = null, string buildpack = null);
         Task<DetailedResult<string>> GetRecentLogs(CloudFoundryApp app);
         Task<DetailedResult<List<string>>> GetUniqueBuildpackNamesAsync(string apiAddress, int retryAmount = 1);
+        DetailedResult CreateManifestFile(string location, AppManifest manifest);
     }
 }

--- a/src/Services/src/CloudFoundry/ICloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/ICloudFoundryService.cs
@@ -17,6 +17,6 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         Task<DetailedResult> DeleteAppAsync(CloudFoundryApp app, bool skipSsl = true, bool removeRoutes = true, int retryAmount = 1);
         Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string pathToDeploymentDirectory, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string stack, bool binaryDeployment, string projectName, string manifestPath = null, string buildpack = null);
         Task<DetailedResult<string>> GetRecentLogs(CloudFoundryApp app);
-        Task<DetailedResult<List<string>>> GetBuildpackNamesAsync(string apiAddress, int retryAmount = 1);
+        Task<DetailedResult<List<string>>> GetUniqueBuildpackNamesAsync(string apiAddress, int retryAmount = 1);
     }
 }

--- a/src/Services/src/CloudFoundry/ICloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/ICloudFoundryService.cs
@@ -17,5 +17,6 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         Task<DetailedResult> DeleteAppAsync(CloudFoundryApp app, bool skipSsl = true, bool removeRoutes = true, int retryAmount = 1);
         Task<DetailedResult> DeployAppAsync(CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, string appName, string pathToDeploymentDirectory, bool fullFrameworkDeployment, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback, string stack, bool binaryDeployment, string projectName, string manifestPath = null, string buildpack = null);
         Task<DetailedResult<string>> GetRecentLogs(CloudFoundryApp app);
+        Task<DetailedResult<List<string>>> GetBuildpackNamesAsync(string apiAddress, int retryAmount = 1);
     }
 }

--- a/src/Services/src/CloudFoundry/ICloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/ICloudFoundryService.cs
@@ -19,6 +19,6 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         Task<DetailedResult<List<string>>> GetUniqueBuildpackNamesAsync(string apiAddress, int retryAmount = 1);
         DetailedResult CreateManifestFile(string location, AppManifest manifest);
         DetailedResult<AppManifest> ParseManifestFile(string pathToManifestFile);
-        Task<DetailedResult> DeployAppAsync(string appName, string manifestPath, string pathToDeploymentDirectory, CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback);
+        Task<DetailedResult> DeployAppAsync(AppManifest appManifest, CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback);
     }
 }

--- a/src/Services/src/DetailedResult.cs
+++ b/src/Services/src/DetailedResult.cs
@@ -39,7 +39,7 @@ namespace Tanzu.Toolkit.Services
             Content = content;
         }
 
-        public T Content { get; internal set; }
+        public T Content { get; set; }
     }
 
     public enum FailureType

--- a/src/Services/src/File/FileService.cs
+++ b/src/Services/src/File/FileService.cs
@@ -130,5 +130,10 @@ namespace Tanzu.Toolkit.Services.File
             string uniqueFileName = fileName + DateTimeOffset.Now.ToUnixTimeSeconds().ToString();
             return Path.Combine(VsixPackageBaseDir, "tmp", uniqueFileName);
         }
+
+        public void DeleteFile(string filePath)
+        {
+            System.IO.File.Delete(filePath);
+        }
     }
 }

--- a/src/Services/src/File/FileService.cs
+++ b/src/Services/src/File/FileService.cs
@@ -109,5 +109,15 @@ namespace Tanzu.Toolkit.Services.File
         {
             return System.IO.File.ReadAllText(filePath);
         }
+
+        public string[] ReadFileLines(string filePath)
+        {
+            return System.IO.File.ReadAllLines(filePath);
+        }
+
+        public bool FileExists(string filePath)
+        {
+            return System.IO.File.Exists(filePath);
+        }
     }
 }

--- a/src/Services/src/File/FileService.cs
+++ b/src/Services/src/File/FileService.cs
@@ -71,6 +71,11 @@ namespace Tanzu.Toolkit.Services.File
             }
         }
 
+        public bool DirectoryExists(string dirPath)
+        {
+            return Directory.Exists(dirPath);
+        }
+
         public bool DirContainsFiles(string dirPath)
         {
             return Directory.Exists(dirPath) && Directory.GetFiles(dirPath).Length > 0;

--- a/src/Services/src/File/FileService.cs
+++ b/src/Services/src/File/FileService.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.IO;
 
-namespace Tanzu.Toolkit.Services.FileLocator
+namespace Tanzu.Toolkit.Services.File
 {
-    public class FileLocatorService : IFileLocatorService
+    public class FileService : IFileService
     {
         private const string _cfCliV6ExeName = "cf6.exe";
         private const string _cfCliV6Dir = "Resources";
@@ -18,7 +18,7 @@ namespace Tanzu.Toolkit.Services.FileLocator
         private readonly string _pathToCf7Exe;
         private readonly string _vsixBaseDirPath;
 
-        public FileLocatorService(string vsixBaseDirPath)
+        public FileService(string vsixBaseDirPath)
         {
             _vsixBaseDirPath = vsixBaseDirPath;
 
@@ -52,14 +52,14 @@ namespace Tanzu.Toolkit.Services.FileLocator
                 switch (_cliVersion)
                 {
                     case 6:
-                        if (File.Exists(_pathToCf6Exe))
+                        if (System.IO.File.Exists(_pathToCf6Exe))
                         {
                             return _pathToCf6Exe;
                         }
 
                         break;
                     case 7:
-                        if (File.Exists(_pathToCf7Exe))
+                        if (System.IO.File.Exists(_pathToCf7Exe))
                         {
                             return _pathToCf7Exe;
                         }
@@ -98,6 +98,16 @@ namespace Tanzu.Toolkit.Services.FileLocator
             {
                 return Path.Combine(VsixPackageBaseDir, _defaultCfCliDir, _defaultCfCliConfigFileName);
             }
+        }
+
+        public void WriteTextToFile(string filePath, string contentsToWrite)
+        {
+            System.IO.File.WriteAllText(filePath, contentsToWrite);
+        }
+
+        public string ReadFileContents(string filePath)
+        {
+            return System.IO.File.ReadAllText(filePath);
         }
     }
 }

--- a/src/Services/src/File/FileService.cs
+++ b/src/Services/src/File/FileService.cs
@@ -124,5 +124,11 @@ namespace Tanzu.Toolkit.Services.File
         {
             return System.IO.File.Exists(filePath);
         }
+
+        public string GetUniquePathForTempFile(string fileName = "")
+        {
+            string uniqueFileName = fileName + DateTimeOffset.Now.ToUnixTimeSeconds().ToString();
+            return Path.Combine(VsixPackageBaseDir, "tmp", uniqueFileName);
+        }
     }
 }

--- a/src/Services/src/File/FileService.cs
+++ b/src/Services/src/File/FileService.cs
@@ -127,8 +127,15 @@ namespace Tanzu.Toolkit.Services.File
 
         public string GetUniquePathForTempFile(string fileName = "")
         {
+            string tmpDirPath = Path.Combine(VsixPackageBaseDir, "tmp");
+
+            if (!Directory.Exists(tmpDirPath))
+            {
+                Directory.CreateDirectory(tmpDirPath);
+            }
+
             string uniqueFileName = fileName + DateTimeOffset.Now.ToUnixTimeSeconds().ToString();
-            return Path.Combine(VsixPackageBaseDir, "tmp", uniqueFileName);
+            return Path.Combine(tmpDirPath, uniqueFileName);
         }
 
         public void DeleteFile(string filePath)

--- a/src/Services/src/File/IFileService.cs
+++ b/src/Services/src/File/IFileService.cs
@@ -1,6 +1,6 @@
-﻿namespace Tanzu.Toolkit.Services.FileLocator
+﻿namespace Tanzu.Toolkit.Services.File
 {
-    public interface IFileLocatorService
+    public interface IFileService
     {
         string FullPathToCfExe { get; }
         string VsixPackageBaseDir { get; }
@@ -9,5 +9,7 @@
         string PathToCfCliConfigFile { get; }
 
         bool DirContainsFiles(string dirPath);
+        string ReadFileContents(string filePath);
+        void WriteTextToFile(string filePath, string contentsToWrite);
     }
 }

--- a/src/Services/src/File/IFileService.cs
+++ b/src/Services/src/File/IFileService.cs
@@ -9,6 +9,7 @@
         string PathToCfCliConfigFile { get; }
 
         bool DirContainsFiles(string dirPath);
+        bool DirectoryExists(string dirPath);
         bool FileExists(string filePath);
         string ReadFileContents(string filePath);
         string[] ReadFileLines(string filePath);

--- a/src/Services/src/File/IFileService.cs
+++ b/src/Services/src/File/IFileService.cs
@@ -9,7 +9,9 @@
         string PathToCfCliConfigFile { get; }
 
         bool DirContainsFiles(string dirPath);
+        bool FileExists(string filePath);
         string ReadFileContents(string filePath);
+        string[] ReadFileLines(string filePath);
         void WriteTextToFile(string filePath, string contentsToWrite);
     }
 }

--- a/src/Services/src/File/IFileService.cs
+++ b/src/Services/src/File/IFileService.cs
@@ -11,6 +11,7 @@
         bool DirContainsFiles(string dirPath);
         bool DirectoryExists(string dirPath);
         bool FileExists(string filePath);
+        string GetUniquePathForTempFile(string fileName = "");
         string ReadFileContents(string filePath);
         string[] ReadFileLines(string filePath);
         void WriteTextToFile(string filePath, string contentsToWrite);

--- a/src/Services/src/File/IFileService.cs
+++ b/src/Services/src/File/IFileService.cs
@@ -8,6 +8,7 @@
         int CliVersion { get; set; }
         string PathToCfCliConfigFile { get; }
 
+        void DeleteFile(string filePath);
         bool DirContainsFiles(string dirPath);
         bool DirectoryExists(string dirPath);
         bool FileExists(string filePath);

--- a/src/Services/src/Logging/LoggingService.cs
+++ b/src/Services/src/Logging/LoggingService.cs
@@ -1,5 +1,5 @@
 ﻿using Serilog;
-using Tanzu.Toolkit.Services.FileLocator;
+using Tanzu.Toolkit.Services.File;
 
 namespace Tanzu.Toolkit.Services.Logging
 {
@@ -7,12 +7,12 @@ namespace Tanzu.Toolkit.Services.Logging
     {
         public ILogger Logger { get; }
 
-        public LoggingService(IFileLocatorService fileLocatorService)
+        public LoggingService(IFileService fileService)
         {
             Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
                 .WriteTo.File(
-                    path: fileLocatorService.PathToLogsFile,
+                    path: fileService.PathToLogsFile,
                     shared: true, // allow multiple processes to share same log file
                     fileSizeLimitBytes: 32768, // 32 KiB
                     rollOnFileSizeLimit: true,

--- a/src/Services/src/Tanzu.Toolkit.Services.csproj
+++ b/src/Services/src/Tanzu.Toolkit.Services.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
+    <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/test/CfCli/CfCliServiceTests.cs
+++ b/src/Services/test/CfCli/CfCliServiceTests.cs
@@ -1386,7 +1386,6 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
             Assert.AreEqual(_fakeFailureCmdResult, result.CmdResult);
         }
 
-
         [TestMethod]
         [TestCategory("GetRecentAppLogs")]
         public async Task GetRecentAppLogs_ThrowsInvalidRefreshTokenException_WhenTargetOrgReportsInvalidRefreshToken()
@@ -1481,6 +1480,5 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
             Assert.IsNotNull(thrownException);
             Assert.IsTrue(thrownException is InvalidRefreshTokenException);
         }
-
     }
 }

--- a/src/Services/test/CfCli/CfCliServiceTests.cs
+++ b/src/Services/test/CfCli/CfCliServiceTests.cs
@@ -8,7 +8,7 @@ using System.Security;
 using System.Threading.Tasks;
 using Tanzu.Toolkit.Services.CfCli;
 using Tanzu.Toolkit.Services.CommandProcess;
-using Tanzu.Toolkit.Services.FileLocator;
+using Tanzu.Toolkit.Services.File;
 using Tanzu.Toolkit.Services.Logging;
 using static Tanzu.Toolkit.Services.OutputHandler.OutputHandler;
 
@@ -34,7 +34,7 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
 
         private Mock<ICfCliService> _mockCfCliService;
         private Mock<ICommandProcessService> _mockCommandProcessService;
-        private Mock<IFileLocatorService> _mockFileLocatorService;
+        private Mock<IFileService> _mockFileService;
         private Mock<ILoggingService> _mockLoggingService;
         private Mock<ILogger> _mockLogger;
 
@@ -44,7 +44,7 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
             var serviceCollection = new ServiceCollection();
             _mockCfCliService = new Mock<ICfCliService>();
             _mockCommandProcessService = new Mock<ICommandProcessService>();
-            _mockFileLocatorService = new Mock<IFileLocatorService>();
+            _mockFileService = new Mock<IFileService>();
             _mockLoggingService = new Mock<ILoggingService>();
 
             _mockLogger = new Mock<ILogger>();
@@ -52,19 +52,19 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
 
             serviceCollection.AddSingleton(_mockCfCliService.Object);
             serviceCollection.AddSingleton(_mockCommandProcessService.Object);
-            serviceCollection.AddSingleton(_mockFileLocatorService.Object);
+            serviceCollection.AddSingleton(_mockFileService.Object);
             serviceCollection.AddSingleton(_mockLoggingService.Object);
 
             _services = serviceCollection.BuildServiceProvider();
 
-            _mockFileLocatorService.SetupGet(mock => mock.FullPathToCfExe).Returns(_fakePathToCfExe);
+            _mockFileService.SetupGet(mock => mock.FullPathToCfExe).Returns(_fakePathToCfExe);
             _sut = new CfCliService(_fakeCfCliConfigFilePath, _services);
         }
 
         [TestCleanup]
         public void TestCleanup()
         {
-            _mockFileLocatorService.VerifyAll();
+            _mockFileService.VerifyAll();
             _mockCommandProcessService.VerifyAll();
             _mockLogger.VerifyAll();
         }
@@ -143,7 +143,7 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
         [TestCategory("RunCfCommandAsync")]
         public async Task RunCfCommandAsync_ReturnsFalseResult_WhenCfExeCouldNotBeFound()
         {
-            _mockFileLocatorService.SetupGet(mock => mock.FullPathToCfExe).Returns((string)null);
+            _mockFileService.SetupGet(mock => mock.FullPathToCfExe).Returns((string)null);
 
             DetailedResult result = await _sut.RunCfCommandAsync(_fakeArguments);
 
@@ -254,7 +254,7 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
         [TestCategory("ExecuteCfCliCommand")]
         public void ExecuteCfCliCommand_ReturnsFalseResult_WhenCfExeCouldNotBeFound()
         {
-            _mockFileLocatorService.SetupGet(mock => mock.
+            _mockFileService.SetupGet(mock => mock.
               FullPathToCfExe)
                 .Returns((string)null);
 
@@ -1002,7 +1002,7 @@ namespace Tanzu.Toolkit.Services.Tests.CfCli
         {
             var fakeAppName = "my fake app";
 
-            _mockFileLocatorService.SetupGet(m => m.
+            _mockFileService.SetupGet(m => m.
                 FullPathToCfExe)
                     .Returns((string)null);
 

--- a/src/Services/test/CloudFoundry/CloudFoundryServiceTests.cs
+++ b/src/Services/test/CloudFoundry/CloudFoundryServiceTests.cs
@@ -13,7 +13,7 @@ using Tanzu.Toolkit.Services.CloudFoundry;
 using Tanzu.Toolkit.Services.CommandProcess;
 using Tanzu.Toolkit.Services.Dialog;
 using Tanzu.Toolkit.Services.ErrorDialog;
-using Tanzu.Toolkit.Services.FileLocator;
+using Tanzu.Toolkit.Services.File;
 using Tanzu.Toolkit.Services.Logging;
 using static Tanzu.Toolkit.Services.OutputHandler.OutputHandler;
 
@@ -30,7 +30,7 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
         private Mock<ICfCliService> _mockCfCliService;
         private Mock<IErrorDialog> _mockErrorDialogWindowService;
         private Mock<ICommandProcessService> _mockCommandProcessService;
-        private Mock<IFileLocatorService> _mockFileLocatorService;
+        private Mock<IFileService> _mockFileService;
         private Mock<ILoggingService> _mockLoggingService;
         private Mock<ILogger> _mockLogger;
 
@@ -44,7 +44,7 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
             _mockCfCliService = new Mock<ICfCliService>();
             _mockErrorDialogWindowService = new Mock<IErrorDialog>();
             _mockCommandProcessService = new Mock<ICommandProcessService>();
-            _mockFileLocatorService = new Mock<IFileLocatorService>();
+            _mockFileService = new Mock<IFileService>();
             _mockLoggingService = new Mock<ILoggingService>();
 
             _mockLogger = new Mock<ILogger>();
@@ -54,7 +54,7 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
             serviceCollection.AddSingleton(_mockCfCliService.Object);
             serviceCollection.AddSingleton(_mockErrorDialogWindowService.Object);
             serviceCollection.AddSingleton(_mockCommandProcessService.Object);
-            serviceCollection.AddSingleton(_mockFileLocatorService.Object);
+            serviceCollection.AddSingleton(_mockFileService.Object);
             serviceCollection.AddSingleton(_mockLoggingService.Object);
 
             _services = serviceCollection.BuildServiceProvider();
@@ -227,12 +227,12 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
             _mockCfCliService.Setup(m => m.
                 GetApiVersion()).ReturnsAsync((Version)null);
 
-            _mockFileLocatorService.SetupSet(m => m.
+            _mockFileService.SetupSet(m => m.
                 CliVersion = expectedCliVersion).Verifiable();
 
             ConnectResult result = await _sut.ConnectToCFAsync(_fakeValidTarget, _fakeValidUsername, _fakeValidPassword, _skipSsl);
 
-            _mockFileLocatorService.VerifyAll();
+            _mockFileService.VerifyAll();
             _mockCfCliService.VerifyAll();
             _mockErrorDialogWindowService.Verify(m => m.
                 DisplayErrorDialog(CloudFoundryService.CcApiVersionUndetectableErrTitle, CloudFoundryService.CcApiVersionUndetectableErrMsg),
@@ -264,12 +264,12 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
                 _mockCfCliService.Setup(m => m.
                     GetApiVersion()).ReturnsAsync(mockApiVersion);
 
-                _mockFileLocatorService.SetupSet(m => m.
+                _mockFileService.SetupSet(m => m.
                     CliVersion = expectedCliVersion).Verifiable();
 
                 ConnectResult result = await _sut.ConnectToCFAsync(_fakeValidTarget, _fakeValidUsername, _fakeValidPassword, _skipSsl);
 
-                _mockFileLocatorService.VerifyAll();
+                _mockFileService.VerifyAll();
                 _mockCfCliService.VerifyAll();
             }
         }
@@ -299,12 +299,12 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
                 _mockCfCliService.Setup(m => m.
                     GetApiVersion()).ReturnsAsync(mockApiVersion);
 
-                _mockFileLocatorService.SetupSet(m => m.
+                _mockFileService.SetupSet(m => m.
                     CliVersion = expectedCliVersion).Verifiable();
 
                 ConnectResult result = await _sut.ConnectToCFAsync(_fakeValidTarget, _fakeValidUsername, _fakeValidPassword, _skipSsl);
 
-                _mockFileLocatorService.VerifyAll();
+                _mockFileService.VerifyAll();
                 _mockCfCliService.VerifyAll();
             }
         }
@@ -334,12 +334,12 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
                 _mockCfCliService.Setup(m => m.
                     GetApiVersion()).ReturnsAsync(mockApiVersion);
 
-                _mockFileLocatorService.SetupSet(m => m.
+                _mockFileService.SetupSet(m => m.
                     CliVersion = expectedCliVersion).Verifiable();
 
                 ConnectResult result = await _sut.ConnectToCFAsync(_fakeValidTarget, _fakeValidUsername, _fakeValidPassword, _skipSsl);
 
-                _mockFileLocatorService.VerifyAll();
+                _mockFileService.VerifyAll();
                 _mockCfCliService.VerifyAll();
             }
         }
@@ -369,12 +369,12 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
                 _mockCfCliService.Setup(m => m.
                     GetApiVersion()).ReturnsAsync(mockApiVersion);
 
-                _mockFileLocatorService.SetupSet(m => m.
+                _mockFileService.SetupSet(m => m.
                     CliVersion = expectedCliVersion).Verifiable();
 
                 ConnectResult result = await _sut.ConnectToCFAsync(_fakeValidTarget, _fakeValidUsername, _fakeValidPassword, _skipSsl);
 
-                _mockFileLocatorService.VerifyAll();
+                _mockFileService.VerifyAll();
                 _mockCfCliService.VerifyAll();
             }
         }
@@ -1576,7 +1576,7 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
                 mock.PushAppAsync(FakeApp.AppName, FakeApp.ParentSpace.ParentOrg.OrgName, FakeApp.ParentSpace.SpaceName, null, null, _fakeProjectPath, null, null, null, null))
                     .ReturnsAsync(fakeCfPushResponse);
 
-            _mockFileLocatorService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
+            _mockFileService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
 
             DetailedResult result = await _sut.DeployAppAsync(FakeCfInstance, FakeOrg, FakeSpace, FakeApp.AppName, _fakeProjectPath, _defaultFullFWFlag, stdOutCallback: null, stdErrCallback: null, stack: null, binaryDeployment: false, projectName: null, manifestPath: null);
 
@@ -1595,7 +1595,7 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
                 mock.PushAppAsync(FakeApp.AppName, FakeApp.ParentSpace.ParentOrg.OrgName, FakeApp.ParentSpace.SpaceName, null, null, _fakeProjectPath, null, stack, null, null))
                     .ReturnsAsync(_fakeSuccessDetailedResult);
 
-            _mockFileLocatorService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
+            _mockFileService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
 
             DetailedResult result = await _sut.DeployAppAsync(FakeCfInstance, FakeOrg, FakeSpace, FakeApp.AppName, _fakeProjectPath, _defaultFullFWFlag, stdOutCallback: null, stdErrCallback: null, stack: stack, binaryDeployment: false, projectName: null, manifestPath: null);
 
@@ -1613,7 +1613,7 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
                 mock.PushAppAsync(FakeApp.AppName, FakeApp.ParentSpace.ParentOrg.OrgName, FakeApp.ParentSpace.SpaceName, null, null, _fakeProjectPath, expectedBuildpackValue, expectedStackValue, null, null))
                     .ReturnsAsync(_fakeSuccessDetailedResult);
 
-            _mockFileLocatorService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
+            _mockFileService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
 
             bool fullFWIndicator = true;
             DetailedResult result = await _sut.DeployAppAsync(FakeCfInstance, FakeOrg, FakeSpace, FakeApp.AppName, _fakeProjectPath, fullFWIndicator, stdOutCallback: null, stdErrCallback: null, stack: null, binaryDeployment: false, projectName: null, manifestPath: null);
@@ -1625,20 +1625,20 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
         [TestCategory("DeployApp")]
         public async Task DeployAppAsync_ReturnsFalseResult_WhenProjDirContainsNoFiles()
         {
-            _mockFileLocatorService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(false);
+            _mockFileService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(false);
 
             var result = await _sut.DeployAppAsync(FakeCfInstance, FakeOrg, FakeSpace, FakeApp.AppName, _fakeProjectPath, _defaultFullFWFlag, stdOutCallback: null, stdErrCallback: null, stack: null, binaryDeployment: true, projectName: null, manifestPath: null);
 
             Assert.IsFalse(result.Succeeded);
             Assert.IsTrue(result.Explanation.Contains(CloudFoundryService.EmptyOutputDirMessage));
-            _mockFileLocatorService.VerifyAll();
+            _mockFileService.VerifyAll();
         }
 
         [TestMethod]
         [TestCategory("DeployApp")]
         public async Task DeployAppAsync_ReturnsFailedResult_WhenCfCliDeploymentThrowsInvalidRefreshTokenException()
         {
-            _mockFileLocatorService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
+            _mockFileService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
 
             _mockCfCliService.Setup(mock => mock.
                 PushAppAsync(FakeApp.AppName, FakeOrg.OrgName, FakeSpace.SpaceName, It.IsAny<StdOutDelegate>(), It.IsAny<StdErrDelegate>(), _fakeProjectPath, It.IsAny<string>(), It.IsAny<string>(), null, null))
@@ -1655,7 +1655,7 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
         [TestCategory("DeployApp")]
         public async Task DeployAppAsync_SpecifiesBuildpack_AndStartCommand_WhenBinaryDeploymentIsTrue()
         {
-            _mockFileLocatorService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
+            _mockFileService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
 
             var expectedProjectName = "junk proj name";
             var expectedBuildpack = "binary_buildpack";
@@ -1694,7 +1694,7 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
         [TestCategory("DeployApp")]
         public async Task DeployAppAsync_SpecifiesDotNetCoreBuildpack_WhenBinaryDeploymentIsTrue_AndStackIsLinux()
         {
-            _mockFileLocatorService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
+            _mockFileService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
 
             var expectedProjectName = "junk proj name";
             var expectedBuildpack = "dotnet_core_buildpack";

--- a/src/Services/test/CloudFoundry/CloudFoundryServiceTests.cs
+++ b/src/Services/test/CloudFoundry/CloudFoundryServiceTests.cs
@@ -15,7 +15,6 @@ using Tanzu.Toolkit.Services.CommandProcess;
 using Tanzu.Toolkit.Services.ErrorDialog;
 using Tanzu.Toolkit.Services.File;
 using Tanzu.Toolkit.Services.Logging;
-using static Tanzu.Toolkit.Services.OutputHandler.OutputHandler;
 
 namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
 {
@@ -33,8 +32,6 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
         private Mock<IFileService> _mockFileService;
         private Mock<ILoggingService> _mockLoggingService;
         private Mock<ILogger> _mockLogger;
-
-        private readonly bool _defaultFullFWFlag = false;
 
         [TestInitialize]
         public void TestInit()
@@ -1579,7 +1576,7 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
 
             _mockFileService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
 
-            DetailedResult result = await _sut.DeployAppAsync(FakeCfInstance, FakeOrg, FakeSpace, FakeApp.AppName, _fakeProjectPath, _defaultFullFWFlag, stdOutCallback: _fakeOutCallback, stdErrCallback: _fakeErrCallback, stack: null, binaryDeployment: false, projectName: null, manifestPath: _fakeManifestPath);
+            DetailedResult result = await _sut.DeployAppAsync(FakeApp.AppName, _fakeManifestPath, _fakeProjectPath, FakeCfInstance, FakeOrg, FakeSpace, _fakeOutCallback, _fakeErrCallback);
 
             Assert.IsFalse(result.Succeeded);
             Assert.IsTrue(result.Explanation.Contains(fakeFailureExplanation));
@@ -1598,7 +1595,7 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
 
             _mockFileService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(true);
 
-            DetailedResult result = await _sut.DeployAppAsync(FakeCfInstance, FakeOrg, FakeSpace, FakeApp.AppName, _fakeProjectPath, _defaultFullFWFlag, stdOutCallback: _fakeOutCallback, stdErrCallback: _fakeErrCallback, stack: stack, binaryDeployment: false, projectName: null, manifestPath: _fakeManifestPath);
+            DetailedResult result = await _sut.DeployAppAsync(FakeApp.AppName, _fakeManifestPath, _fakeProjectPath, FakeCfInstance, FakeOrg, FakeSpace, _fakeOutCallback, _fakeErrCallback);
 
             Assert.IsTrue(result.Succeeded);
         }
@@ -1609,7 +1606,7 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
         {
             _mockFileService.Setup(mock => mock.DirContainsFiles(It.IsAny<string>())).Returns(false);
 
-            var result = await _sut.DeployAppAsync(FakeCfInstance, FakeOrg, FakeSpace, FakeApp.AppName, _fakeProjectPath, _defaultFullFWFlag, stdOutCallback: null, stdErrCallback: null, stack: null, binaryDeployment: true, projectName: null, manifestPath: null);
+            DetailedResult result = await _sut.DeployAppAsync(FakeApp.AppName, _fakeManifestPath, _fakeProjectPath, FakeCfInstance, FakeOrg, FakeSpace, _fakeOutCallback, _fakeErrCallback);
 
             Assert.IsFalse(result.Succeeded);
             Assert.IsTrue(result.Explanation.Contains(CloudFoundryService.EmptyOutputDirMessage));
@@ -1626,7 +1623,7 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
                 PushAppAsync(_fakeManifestPath, _fakeProjectPath, FakeOrg.OrgName, FakeSpace.SpaceName, _fakeOutCallback, _fakeErrCallback))
                     .Throws(new InvalidRefreshTokenException());
 
-            var result = await _sut.DeployAppAsync(FakeCfInstance, FakeOrg, FakeSpace, FakeApp.AppName, _fakeProjectPath, _defaultFullFWFlag, stdOutCallback: _fakeOutCallback, stdErrCallback: _fakeErrCallback, stack: null, binaryDeployment: false, projectName: null, manifestPath: _fakeManifestPath);
+            DetailedResult result = await _sut.DeployAppAsync(FakeApp.AppName, _fakeManifestPath, _fakeProjectPath, FakeCfInstance, FakeOrg, FakeSpace, _fakeOutCallback, _fakeErrCallback);
 
             Assert.IsFalse(result.Succeeded);
             Assert.IsNotNull(result.Explanation);

--- a/src/Services/test/CloudFoundry/CloudFoundryServiceTests.cs
+++ b/src/Services/test/CloudFoundry/CloudFoundryServiceTests.cs
@@ -1767,7 +1767,7 @@ namespace Tanzu.Toolkit.Services.Tests.CloudFoundry
                     }
                 }
 
-                foreach (string key in app.Env.Values)
+                foreach (string key in app.Env.Keys)
                 {
                     expectedManifestEntries.Add(key);
                 }

--- a/src/Services/test/File/FileServiceTests.cs
+++ b/src/Services/test/File/FileServiceTests.cs
@@ -1,20 +1,20 @@
 ﻿using System;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Tanzu.Toolkit.Services.FileLocator;
+using Tanzu.Toolkit.Services.File;
 
-namespace Tanzu.Toolkit.Services.Tests.FileLocator
+namespace Tanzu.Toolkit.Services.Tests.File
 {
     [TestClass]
-    public class FileLocatorServiceTests : ServicesTestSupport
+    public class FileServiceTests : ServicesTestSupport
     {
-        private FileLocatorService _sut;
+        private FileService _sut;
 
         [TestInitialize]
         public void TestInit()
         {
             var fakeAssemblyBaseDir = Path.GetDirectoryName(GetType().Assembly.Location);
-            _sut = new FileLocatorService(fakeAssemblyBaseDir);
+            _sut = new FileService(fakeAssemblyBaseDir);
         }
 
         [TestMethod]
@@ -76,7 +76,7 @@ namespace Tanzu.Toolkit.Services.Tests.FileLocator
         public void FullPathToCfExe_ThrowsException_WhenExecutableFileNotFound()
         {
             var fakeAssemblyBaseDir = "/fake/path";
-            _sut = new FileLocatorService(fakeAssemblyBaseDir)
+            _sut = new FileService(fakeAssemblyBaseDir)
             {
                 CliVersion = 7,
             };

--- a/src/Services/test/Resources/cf6.exe
+++ b/src/Services/test/Resources/cf6.exe
@@ -1,3 +1,3 @@
 ﻿THIS IS A FAKE! 
-Tricking the FileLocatorService into thinking 
+Tricking the FileService into thinking 
 there is a real executable at this location.

--- a/src/Services/test/Resources/cf7.exe
+++ b/src/Services/test/Resources/cf7.exe
@@ -1,3 +1,3 @@
 ﻿THIS IS A FAKE! 
-Tricking the FileLocatorService into thinking 
+Tricking the FileService into thinking 
 there is a real executable at this location.

--- a/src/Services/test/ServicesTestSupport.cs
+++ b/src/Services/test/ServicesTestSupport.cs
@@ -2,6 +2,7 @@
 using System.Security;
 using Tanzu.Toolkit.Models;
 using Tanzu.Toolkit.Services.CommandProcess;
+using static Tanzu.Toolkit.Services.OutputHandler.OutputHandler;
 
 namespace Tanzu.Toolkit.Services.Tests
 {
@@ -53,6 +54,9 @@ namespace Tanzu.Toolkit.Services.Tests
         protected static readonly bool _skipSsl = true;
         protected static readonly string _fakeValidAccessToken = "valid token";
         protected static readonly string _fakeProjectPath = "this\\is\\a\\fake\\path";
+        protected static readonly string _fakeManifestPath = "this\\is\\a\\fake\\path"; 
+        protected static readonly StdOutDelegate _fakeOutCallback = content => { };
+        protected static readonly StdErrDelegate _fakeErrCallback = content => { };
 
         protected static readonly CloudFoundryInstance FakeCfInstance = new CloudFoundryInstance("fake cf", _fakeValidTarget);
         protected static readonly CloudFoundryOrganization FakeOrg = new CloudFoundryOrganization("fake org", "fake org guid", FakeCfInstance);

--- a/src/Services/test/ServicesTestSupport.cs
+++ b/src/Services/test/ServicesTestSupport.cs
@@ -1,4 +1,5 @@
-﻿using System.Security;
+﻿using System.Collections.Generic;
+using System.Security;
 using Tanzu.Toolkit.Models;
 using Tanzu.Toolkit.Services.CommandProcess;
 
@@ -95,5 +96,140 @@ namespace Tanzu.Toolkit.Services.Tests
          * This is a real JWT from the Jamestown CF environment which expired on June 8th 2021
          */
         internal static readonly string expiredAccessToken = "eyJhbGciOiJSUzI1NiIsImprdSI6Imh0dHBzOi8vdWFhLnN5cy5qYW1lc3Rvd24uY2YtYXBwLmNvbS90b2tlbl9rZXlzIiwia2lkIjoia2V5LTEiLCJ0eXAiOiJKV1QifQ.eyJqdGkiOiIyNmY3ZGFhNTI5MDM0OGVmOWQyZTRkYTg4MmZiMWMyZiIsInN1YiI6IjY0NzljMjY0LWE3YTQtNGRiYS05MGFmLTk1MGE4YTMyODE5ZSIsInNjb3BlIjpbIm9wZW5pZCIsInJvdXRpbmcucm91dGVyX2dyb3Vwcy53cml0ZSIsIm5ldHdvcmsud3JpdGUiLCJzY2ltLnJlYWQiLCJjbG91ZF9jb250cm9sbGVyLmFkbWluIiwidWFhLnVzZXIiLCJyb3V0aW5nLnJvdXRlcl9ncm91cHMucmVhZCIsImNsb3VkX2NvbnRyb2xsZXIucmVhZCIsInBhc3N3b3JkLndyaXRlIiwiY2xvdWRfY29udHJvbGxlci53cml0ZSIsIm5ldHdvcmsuYWRtaW4iLCJkb3BwbGVyLmZpcmVob3NlIiwic2NpbS53cml0ZSJdLCJjbGllbnRfaWQiOiJjZiIsImNpZCI6ImNmIiwiYXpwIjoiY2YiLCJncmFudF90eXBlIjoicGFzc3dvcmQiLCJ1c2VyX2lkIjoiNjQ3OWMyNjQtYTdhNC00ZGJhLTkwYWYtOTUwYThhMzI4MTllIiwib3JpZ2luIjoidWFhIiwidXNlcl9uYW1lIjoiYWRtaW4iLCJlbWFpbCI6ImFkbWluIiwiYXV0aF90aW1lIjoxNjIzMTY0ODE2LCJyZXZfc2lnIjoiNDFkOTJiYiIsImlhdCI6MTYyMzE4MTEzNSwiZXhwIjoxNjIzMTg4MzM1LCJpc3MiOiJodHRwczovL3VhYS5zeXMuamFtZXN0b3duLmNmLWFwcC5jb20vb2F1dGgvdG9rZW4iLCJ6aWQiOiJ1YWEiLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciIsInNjaW0iLCJwYXNzd29yZCIsImNmIiwidWFhIiwib3BlbmlkIiwiZG9wcGxlciIsIm5ldHdvcmsiLCJyb3V0aW5nLnJvdXRlcl9ncm91cHMiXX0.qCfIxuJb2Xv21pq9idUO44PY50n4FY1cTwpmoWbjAmVs2Cu1smeD2L8gJFSZtg04MlKEJLspfSwfsAfu4YTbUB_iWyBmrZybnZFNrU335z8jReAnHTD5Nq5wVvPLNKdwVy3VyyhHTpD7BQ-oTPLDFaVTysoqR8C13ln0Sbr8jctOHVGRS8sOxJVedtRrLAhQUtZJUPpxbq4msFa0YWLQfXRwWTUc4boYOqtHx1jXg5T2qOJDcUF8MvvLE5ROnfsRciMEtCjCqJsteIEG2lfHcE7JwH3XXSJoiz1pIBoDw1DEUplHmNgQ1saK7tNQu-gg4RVWHFKvqhnGwT94buwHkA";
+
+        internal readonly AppManifest exampleManifest = new AppManifest
+        {
+            Version = 1,
+            Applications = new List<AppConfig>
+                {
+                    new AppConfig
+                    {
+                        Name = "app1",
+                        Buildpacks = new List<string>
+                        {
+                            "ruby_buildpack",
+                            "java_buildpack",
+                        },
+                        Env = new Dictionary<string, string>
+                        {
+                            {"VAR1", "value1" },
+                            {"VAR2", "value2" },
+                        },
+                        Routes = new List<RouteConfig>
+                        {
+                            new RouteConfig
+                            {
+                                Route = "route.example.com",
+                            },
+                            new RouteConfig
+                            {
+                                Route = "another-route.example.com",
+                                Protocol = "http2"
+                            },
+                        },
+                        Services = new List<ServiceConfig>
+                        {
+                            new ServiceConfig
+                            {
+                                Name = "my-service1",
+                            },
+                            new ServiceConfig
+                            {
+                                Name = "my-service2",
+                            },
+                            new ServiceConfig
+                            {
+                                Name = "my-service-with-arbitrary-params",
+                                BindingName = "my-binding",
+                                Parameters = new Dictionary<object, object>
+                                {
+                                    { "key1", "value1" },
+                                    { "key2", "value2" },
+                                }
+                            },
+                        },
+                        Stack = "cflinuxfs3",
+                        Metadata = new MetadataConfig
+                        {
+                            Annotations = new Dictionary<string, string>
+                            {
+                                { "contact", "bob@example.com jane@example.com" },
+                            },
+                            Labels = new Dictionary<string, string>
+                            {
+                                { "sensitive", "true" },
+                            },
+                        },
+                        Processes = new List<ProcessConfig>
+                        {
+                            new ProcessConfig
+                            {
+                                Type = "web",
+                                Command = "start-web.sh",
+                                DiskQuota = "512M",
+                                HealthCheckHttpEndpoint = "/healthcheck",
+                                HealthCheckType = "http",
+                                HealthCheckInvocationTimeout = 10,
+                                Instances = 3,
+                                Memory = "500M",
+                                Timeout = 10,
+                            },
+                            new ProcessConfig
+                            {
+                                Type = "worker",
+                                Command = "start-worker.sh",
+                                DiskQuota = "1G",
+                                HealthCheckType = "process",
+                                Instances = 2,
+                                Memory = "256M",
+                                Timeout = 15,
+                            },
+                        }
+                    },
+                    new AppConfig
+                    {
+                        Name = "app2",
+                        Env = new Dictionary<string, string>
+                        {
+                            { "VAR1", "value1" },
+                        },
+                        Processes = new List<ProcessConfig>
+                        {
+                            new ProcessConfig
+                            {
+                                Type = "web",
+                                Instances = 1,
+                                Memory = "256M",
+                            },
+                        },
+                        Sidecars = new List<SidecarConfig>
+                        {
+                            new SidecarConfig
+                            {
+                                Name = "authenticator",
+                                ProcessTypes = new List<string>
+                                {
+                                    "web",
+                                    "worker",
+                                },
+                                Command = "bundle exec run-authenticator",
+                                Memory = "800M",
+                            },
+                            new SidecarConfig
+                            {
+                                Name = "upcaser",
+                                ProcessTypes = new List<string>
+                                {
+                                    "worker",
+                                },
+                                Command = "./tr-server",
+                                Memory = "2G",
+                            }
+                        }
+                    }
+                }
+        };
+
+        internal readonly string exampleManifestYaml = System.IO.File.ReadAllText("TestFakes/SampleManifest.yml");
     }
 }

--- a/src/Services/test/ServicesTestSupport.cs
+++ b/src/Services/test/ServicesTestSupport.cs
@@ -127,26 +127,9 @@ namespace Tanzu.Toolkit.Services.Tests
                                 Protocol = "http2"
                             },
                         },
-                        Services = new List<ServiceConfig>
-                        {
-                            new ServiceConfig
-                            {
-                                Name = "my-service1",
-                            },
-                            new ServiceConfig
-                            {
-                                Name = "my-service2",
-                            },
-                            new ServiceConfig
-                            {
-                                Name = "my-service-with-arbitrary-params",
-                                BindingName = "my-binding",
-                                Parameters = new Dictionary<object, object>
-                                {
-                                    { "key1", "value1" },
-                                    { "key2", "value2" },
-                                }
-                            },
+                        Services = new List<string> {
+                            "my-service1",
+                            "my-service2",
                         },
                         Stack = "cflinuxfs3",
                         Metadata = new MetadataConfig

--- a/src/Services/test/ServicesTestSupport.cs
+++ b/src/Services/test/ServicesTestSupport.cs
@@ -116,8 +116,11 @@ namespace Tanzu.Toolkit.Services.Tests
                         },
                         Env = new Dictionary<string, string>
                         {
-                            {"VAR1", "value1" },
-                            {"VAR2", "value2" },
+                            {"my_snake_case_var_key", "my_snake_case_var_val" },
+                            {"my-kebab-case-var-key", "my-kebab-case-var-val" },
+                            {"myCamelCaseVarKey", "myCamelCaseVarVal" },
+                            {"MyPascalCaseVarKey", "MyPascalCaseVarVal" },
+                            {"MY_UPPER_CASE_VAR_KEY", "MY_UPPER_CASE_VAR_VAL" },
                         },
                         Routes = new List<RouteConfig>
                         {

--- a/src/Services/test/Tanzu.Toolkit.Services.Tests.csproj
+++ b/src/Services/test/Tanzu.Toolkit.Services.Tests.csproj
@@ -33,6 +33,9 @@
     <None Update="Resources\cf7.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TestFakes\SampleManifest.yml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Services/test/TestFakes/SampleManifest.yml
+++ b/src/Services/test/TestFakes/SampleManifest.yml
@@ -15,11 +15,6 @@ applications:
   services:
   - my-service1
   - my-service2
-  - name: my-service-with-arbitrary-params
-    binding_name: my-binding
-    parameters:
-      key1: value1
-      key2: value2
   stack: cflinuxfs3
   metadata:
     annotations:

--- a/src/Services/test/TestFakes/SampleManifest.yml
+++ b/src/Services/test/TestFakes/SampleManifest.yml
@@ -1,0 +1,61 @@
+﻿---
+version: 1
+applications:
+- name: app1
+  buildpacks:
+  - ruby_buildpack
+  - java_buildpack
+  env:
+    VAR1: value1
+    VAR2: value2
+  routes:
+  - route: route.example.com
+  - route: another-route.example.com
+    protocol: http2
+  services:
+  - my-service1
+  - my-service2
+  - name: my-service-with-arbitrary-params
+    binding_name: my-binding
+    parameters:
+      key1: value1
+      key2: value2
+  stack: cflinuxfs3
+  metadata:
+    annotations:
+      contact: "bob@example.com jane@example.com"
+    labels:
+      sensitive: true
+  processes:
+  - type: web
+    command: start-web.sh
+    disk_quota: 512M
+    health-check-http-endpoint: /healthcheck
+    health-check-type: http
+    health-check-invocation-timeout: 10
+    instances: 3
+    memory: 500M
+    timeout: 10
+  - type: worker
+    command: start-worker.sh
+    disk_quota: 1G
+    health-check-type: process
+    instances: 2
+    memory: 256M
+    timeout: 15
+- name: app2
+  env:
+    VAR1: value1
+  processes:
+  - type: web
+    instances: 1
+    memory: 256M
+  sidecars:
+  - name: authenticator
+    process_types: [ 'web', 'worker' ]
+    command: bundle exec run-authenticator
+    memory: 800M
+  - name: upcaser
+    process_types: [ 'worker' ]
+    command: ./tr-server
+    memory: 2G 

--- a/src/ViewModels/src/AbstractViewModel.cs
+++ b/src/ViewModels/src/AbstractViewModel.cs
@@ -5,6 +5,7 @@ using Serilog;
 using Tanzu.Toolkit.Services;
 using Tanzu.Toolkit.Services.CloudFoundry;
 using Tanzu.Toolkit.Services.Dialog;
+using Tanzu.Toolkit.Services.File;
 using Tanzu.Toolkit.Services.Logging;
 using Tanzu.Toolkit.Services.Threading;
 using Tanzu.Toolkit.Services.ViewLocator;
@@ -25,6 +26,7 @@ namespace Tanzu.Toolkit.ViewModels
             ViewLocatorService = services.GetRequiredService<IViewLocatorService>();
             ThreadingService = services.GetRequiredService<IThreadingService>();
             UiDispatcherService = services.GetRequiredService<IUiDispatcherService>();
+            FileService = services.GetRequiredService<IFileService>();
             var logSvc = services.GetRequiredService<ILoggingService>();
             Logger = logSvc.Logger;
         }
@@ -40,6 +42,8 @@ namespace Tanzu.Toolkit.ViewModels
         public IUiDispatcherService UiDispatcherService { get; }
 
         public IDialogService DialogService { get; }
+
+        public IFileService FileService { get; }
 
         public ILogger Logger { get; }
 

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -47,7 +47,9 @@ namespace Tanzu.Toolkit.ViewModels
         private string _targetName;
         private bool _isLoggedIn;
         private string _selectedStack;
+        private string _selectedBuildpack;
         private List<string> _stackOptions = new List<string> { "windows", "cflinuxfs3" };
+        private List<string> _buildpackOptions = new List<string> { "junk", "fix this", "not real" };
         private bool _binaryDeployment;
         private string _deploymentButtonLabel;
         private bool _expanded;
@@ -238,6 +240,17 @@ namespace Tanzu.Toolkit.ViewModels
             }
         }
 
+        public string SelectedBuildpack
+        {
+            get => _selectedBuildpack;
+
+            set
+            {
+                _selectedBuildpack = value;
+                RaisePropertyChangedEvent("SelectedBuildpack");
+            }
+        }
+
         public CloudFoundryOrganization SelectedOrg
         {
             get => _selectedOrg;
@@ -307,6 +320,11 @@ namespace Tanzu.Toolkit.ViewModels
         public List<string> StackOptions
         {
             get => _stackOptions;
+        }
+
+        public List<string> BuildpackOptions
+        {
+            get => _buildpackOptions;
         }
 
         public bool DeploymentInProgress { get; internal set; }
@@ -442,7 +460,8 @@ namespace Tanzu.Toolkit.ViewModels
                 stack: SelectedStack,
                 binaryDeployment: BinaryDeployment,
                 projectName: _projectName,
-                manifestPath: ManifestPath);
+                manifestPath: ManifestPath,
+                buildpack: SelectedBuildpack);
 
             if (!deploymentResult.Succeeded)
             {

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -57,6 +57,7 @@ namespace Tanzu.Toolkit.ViewModels
         private string _deploymentButtonLabel;
         private bool _expanded;
         private string _expansionButtonText;
+        private AppManifest _appManifest;
 
         public DeploymentDialogViewModel(IServiceProvider services, string projectName, string directoryOfProjectToDeploy, string targetFrameworkMoniker)
             : base(services)
@@ -145,13 +146,8 @@ namespace Tanzu.Toolkit.ViewModels
 
                     if (parsingResult.Succeeded)
                     {
-                        var appManifest = parsingResult.Content;
-
-                        // TODO: decide how to handle multiple apps specified in the same manifest
-
-                        SetAppNameFromManifest(appManifest);
-                        SetStackFromManifest(appManifest);
-                        SetBuildpacksFromManifest(appManifest);
+                        ManifestModel = parsingResult.Content;
+                        SetViewModelValuesFromManifest(ManifestModel);
                     }
                     else
                     {
@@ -377,6 +373,12 @@ namespace Tanzu.Toolkit.ViewModels
             }
         }
 
+        public AppManifest ManifestModel
+        {
+            get => _appManifest; 
+            set => _appManifest = value;
+        }
+
         public bool CanDeployApp(object arg)
         {
             return !string.IsNullOrEmpty(AppName) && IsLoggedIn && SelectedOrg != null && SelectedSpace != null;
@@ -520,9 +522,7 @@ namespace Tanzu.Toolkit.ViewModels
         internal async Task StartDeployment()
         {
             var deploymentResult = await CloudFoundryService.DeployAppAsync(
-                AppName,
-                ManifestPath,
-                DeploymentDirectoryPath,
+                ManifestModel,
                 SelectedSpace.ParentOrg.ParentCf,
                 SelectedSpace.ParentOrg,
                 SelectedSpace,
@@ -570,6 +570,12 @@ namespace Tanzu.Toolkit.ViewModels
             {
                 ManifestPath = null;
             }
+        }
+        private void SetViewModelValuesFromManifest(AppManifest manifest)
+        {
+            SetAppNameFromManifest(manifest);
+            SetStackFromManifest(manifest);
+            SetBuildpacksFromManifest(manifest);
         }
 
         private void SetAppNameFromManifest(AppManifest appManifest)

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -182,7 +182,7 @@ namespace Tanzu.Toolkit.ViewModels
 
             set
             {
-                if (Directory.Exists(value))
+                if (FileService.DirectoryExists(value))
                 {
                     _directoryPath = value;
                     DirectoryPathLabel = value;
@@ -520,19 +520,14 @@ namespace Tanzu.Toolkit.ViewModels
         internal async Task StartDeployment()
         {
             var deploymentResult = await CloudFoundryService.DeployAppAsync(
+                AppName,
+                ManifestPath,
+                DeploymentDirectoryPath,
                 SelectedSpace.ParentOrg.ParentCf,
                 SelectedSpace.ParentOrg,
                 SelectedSpace,
-                AppName,
-                DeploymentDirectoryPath,
-                _fullFrameworkDeployment,
                 stdOutCallback: OutputViewModel.AppendLine,
-                stdErrCallback: OutputViewModel.AppendLine,
-                stack: SelectedStack,
-                binaryDeployment: BinaryDeployment,
-                projectName: _projectName,
-                manifestPath: ManifestPath,
-                buildpack: SelectedBuildpacks.Last());
+                stdErrCallback: OutputViewModel.AppendLine);
 
             if (!deploymentResult.Succeeded)
             {
@@ -563,11 +558,11 @@ namespace Tanzu.Toolkit.ViewModels
             var expectedManifestLocation1 = Path.Combine(PathToProjectRootDir, "manifest.yaml");
             var expectedManifestLocation2 = Path.Combine(PathToProjectRootDir, "manifest.yml");
 
-            if (File.Exists(expectedManifestLocation1))
+            if (FileService.FileExists(expectedManifestLocation1))
             {
                 ManifestPath = expectedManifestLocation1;
             }
-            else if (File.Exists(expectedManifestLocation2))
+            else if (FileService.FileExists(expectedManifestLocation2))
             {
                 ManifestPath = expectedManifestLocation2;
             }

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -369,6 +369,20 @@ namespace Tanzu.Toolkit.ViewModels
             set => _appManifest = value;
         }
 
+        private bool _buildpacksLoading;
+
+        public bool BuildpacksLoading
+        {
+            get { return _buildpacksLoading; }
+
+            set
+            {
+                _buildpacksLoading = value;
+                RaisePropertyChangedEvent("BuildpacksLoading");
+            }
+        }
+
+
         public bool CanDeployApp(object arg)
         {
             return !string.IsNullOrEmpty(AppName) && IsLoggedIn && SelectedOrg != null && SelectedSpace != null;
@@ -468,6 +482,7 @@ namespace Tanzu.Toolkit.ViewModels
             }
             else
             {
+                BuildpacksLoading = true;
                 var buildpacksRespsonse = await CloudFoundryService.GetUniqueBuildpackNamesAsync(TasExplorerViewModel.TasConnection.CloudFoundryInstance.ApiAddress);
 
                 if (buildpacksRespsonse.Succeeded)
@@ -482,10 +497,12 @@ namespace Tanzu.Toolkit.ViewModels
                     }
 
                     BuildpackOptions = bpOtps;
+                    BuildpacksLoading = false;
                 }
                 else
                 {
                     BuildpackOptions = new List<BuildpackListItem>();
+                    BuildpacksLoading = false;
 
                     Logger.Error(GetBuildpacksFailureMsg + " {BuildpacksResponseError}", buildpacksRespsonse.Explanation);
                     _errorDialogService.DisplayErrorDialog(GetBuildpacksFailureMsg, buildpacksRespsonse.Explanation);

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -53,7 +53,6 @@ namespace Tanzu.Toolkit.ViewModels
         private ObservableCollection<string> _selectedBuildpacks;
         private List<string> _stackOptions = new List<string> { "windows", "cflinuxfs3" };
         private List<string> _buildpackOptions;
-        private string _deploymentButtonLabel;
         private bool _expanded;
         private string _expansionButtonText;
         private AppManifest _appManifest;
@@ -201,17 +200,6 @@ namespace Tanzu.Toolkit.ViewModels
             {
                 _directoryPathLabel = value;
                 RaisePropertyChangedEvent("DirectoryPathLabel");
-            }
-        }
-
-        public string DeploymentButtonLabel
-        {
-            get => _deploymentButtonLabel;
-
-            set
-            {
-                _deploymentButtonLabel = value;
-                RaisePropertyChangedEvent("DeploymentButtonLabel");
             }
         }
 

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -459,7 +459,7 @@ namespace Tanzu.Toolkit.ViewModels
             }
             else
             {
-                var buildpacksRespsonse = await CloudFoundryService.GetBuildpackNamesAsync(TasExplorerViewModel.TasConnection.CloudFoundryInstance.ApiAddress);
+                var buildpacksRespsonse = await CloudFoundryService.GetUniqueBuildpackNamesAsync(TasExplorerViewModel.TasConnection.CloudFoundryInstance.ApiAddress);
 
                 if (buildpacksRespsonse.Succeeded)
                 {

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -402,6 +402,7 @@ namespace Tanzu.Toolkit.ViewModels
                 IsLoggedIn = true;
 
                 ThreadingService.StartTask(UpdateCfOrgOptions);
+                ThreadingService.StartTask(UpdateBuildpackOptions);
             }
         }
 

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -82,6 +82,18 @@ namespace Tanzu.Toolkit.ViewModels
             CfOrgOptions = new List<CloudFoundryOrganization>();
             CfSpaceOptions = new List<CloudFoundrySpace>();
             BuildpackOptions = new List<string>();
+            ManifestModel = new AppManifest
+            {
+                Version = 1,
+                Applications = new List<AppConfig>
+                {
+                    new AppConfig
+                    {
+                        Name = projectName,
+                        Path = directoryOfProjectToDeploy,
+                    }
+                }
+            };
 
             SetManifestIfDefaultExists();
 
@@ -184,6 +196,8 @@ namespace Tanzu.Toolkit.ViewModels
                     DirectoryPathLabel = value;
 
                     BinaryDeployment = value != PathToProjectRootDir;
+
+                    ManifestModel.Applications[0].Path = value;
                 }
                 else
                 {
@@ -251,6 +265,8 @@ namespace Tanzu.Toolkit.ViewModels
                 {
                     _selectedStack = value;
                     RaisePropertyChangedEvent("SelectedStack");
+
+                    ManifestModel.Applications[0].Stack = value;
                 }
             }
         }
@@ -507,6 +523,8 @@ namespace Tanzu.Toolkit.ViewModels
             {
                 SelectedBuildpacks.Add(buildpackName);
                 RaisePropertyChangedEvent("SelectedBuildpacks");
+
+                ManifestModel.Applications[0].Buildpacks = SelectedBuildpacks.ToList();
             }
         }
 
@@ -516,6 +534,8 @@ namespace Tanzu.Toolkit.ViewModels
             {
                 SelectedBuildpacks.Remove(buildpackName);
                 RaisePropertyChangedEvent("SelectedBuildpacks");
+                
+                ManifestModel.Applications[0].Buildpacks = SelectedBuildpacks.ToList();
             }
         }
 
@@ -571,6 +591,7 @@ namespace Tanzu.Toolkit.ViewModels
                 ManifestPath = null;
             }
         }
+
         private void SetViewModelValuesFromManifest(AppManifest manifest)
         {
             SetAppNameFromManifest(manifest);

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -53,7 +53,6 @@ namespace Tanzu.Toolkit.ViewModels
         private ObservableCollection<string> _selectedBuildpacks;
         private List<string> _stackOptions = new List<string> { "windows", "cflinuxfs3" };
         private List<string> _buildpackOptions;
-        private bool _binaryDeployment;
         private string _deploymentButtonLabel;
         private bool _expanded;
         private string _expansionButtonText;
@@ -110,18 +109,6 @@ namespace Tanzu.Toolkit.ViewModels
             _projectName = projectName;
 
             Expanded = false;
-        }
-
-        public bool BinaryDeployment
-        {
-            get => _binaryDeployment;
-
-            internal set
-            {
-                DeploymentButtonLabel = value ? "Push app (from binaries)" : "Push app (from source)";
-                _binaryDeployment = value;
-                RaisePropertyChangedEvent("BinaryDeployment");
-            }
         }
 
         public string AppName
@@ -194,8 +181,6 @@ namespace Tanzu.Toolkit.ViewModels
                 {
                     _directoryPath = value;
                     DirectoryPathLabel = value;
-
-                    BinaryDeployment = value != PathToProjectRootDir;
 
                     ManifestModel.Applications[0].Path = value;
                 }

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -119,6 +119,8 @@ namespace Tanzu.Toolkit.ViewModels
             {
                 _appName = value;
                 RaisePropertyChangedEvent("AppName");
+
+                ManifestModel.Applications[0].Name = value;
             }
         }
 

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -512,6 +512,12 @@ namespace Tanzu.Toolkit.ViewModels
             }
         }
 
+        public void ClearSelectedBuildpacks(object arg = null)
+        {
+            SelectedBuildpacks.Clear();
+            RaisePropertyChangedEvent("SelectedBuildpacks");
+        }
+
         internal async Task StartDeployment()
         {
             var deploymentResult = await CloudFoundryService.DeployAppAsync(

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -487,7 +487,7 @@ namespace Tanzu.Toolkit.ViewModels
 
         public void AddToSelectedBuildpacks(object arg)
         {
-            if (arg is string buildpackName)
+            if (arg is string buildpackName && !SelectedBuildpacks.Contains(buildpackName))
             {
                 SelectedBuildpacks.Add(buildpackName);
                 RaisePropertyChangedEvent("SelectedBuildpacks");

--- a/src/ViewModels/src/DeploymentDialog/IDeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/IDeploymentDialogViewModel.cs
@@ -22,5 +22,6 @@ namespace Tanzu.Toolkit.ViewModels
         Task UpdateCfSpaceOptions();
         void AddToSelectedBuildpacks(object arg);
         void RemoveFromSelectedBuildpacks(object arg);
+        void ClearSelectedBuildpacks(object arg = null);
     }
 }

--- a/src/ViewModels/src/DeploymentDialog/IDeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/IDeploymentDialogViewModel.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 
 namespace Tanzu.Toolkit.ViewModels
 {
@@ -8,6 +10,7 @@ namespace Tanzu.Toolkit.ViewModels
         string ManifestPath { get; set; }
         string DeploymentDirectoryPath { get; set; }
         bool Expanded { get; set; }
+        ObservableCollection<string> SelectedBuildpacks { get; set; }
 
         bool CanDeployApp(object arg);
         bool CanToggleAdvancedOptions(object arg);
@@ -17,5 +20,7 @@ namespace Tanzu.Toolkit.ViewModels
         void ToggleAdvancedOptions(object arg);
         Task UpdateCfOrgOptions();
         Task UpdateCfSpaceOptions();
+        void AddToSelectedBuildpacks(object arg);
+        void RemoveFromSelectedBuildpacks(object arg);
     }
 }

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -92,7 +92,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         [TestCategory("ctor")]
         public void Constructor_SetsBuildpackOptionsToEmptyList()
         {
-            CollectionAssert.AreEqual(new List<string>(), _sut.BuildpackOptions);
+            CollectionAssert.AreEqual(new List<BuildpackListItem>(), _sut.BuildpackOptions);
         }
 
         [TestMethod]
@@ -374,7 +374,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             string expectedErrorTitle = $"{DeploymentDialogViewModel.DeploymentErrorMsg} {_fakeAppName}.";
             string expectedErrorMsg = $"{FakeFailureDetailedResult.Explanation}";
-            
+
             MockCloudFoundryService.Setup(mock => mock.
               DeployAppAsync(expectedManifest, expectedCf, expectedOrg, expectedSpace, expectedStdOutCallback, expectedStdErrCallback))
                 .ReturnsAsync(FakeFailureDetailedResult);
@@ -392,7 +392,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             {
                 FailureType = FailureType.InvalidRefreshToken
             };
-            
+
             _sut.SelectedSpace = _fakeSpace; // space must be set to faciliate lookup of parent org & grandparent cf
 
             AppManifest expectedManifest = _sut.ManifestModel;
@@ -1294,7 +1294,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             await _sut.UpdateBuildpackOptions();
 
-            CollectionAssert.AreEqual(new List<string>(), _sut.BuildpackOptions);
+            CollectionAssert.AreEqual(new List<BuildpackListItem>(), _sut.BuildpackOptions);
             CollectionAssert.Contains(_receivedEvents, "BuildpackOptions");
         }
 
@@ -1321,7 +1321,12 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             await _sut.UpdateBuildpackOptions();
 
-            Assert.AreEqual(fakeBuildpacksContent, _sut.BuildpackOptions);
+            Assert.AreEqual(fakeBuildpacksContent.Count, _sut.BuildpackOptions.Count);
+            foreach (BuildpackListItem bp in _sut.BuildpackOptions)
+            {
+                Assert.IsTrue(fakeBuildpacksContent.Contains(bp.Name));
+            }
+
             CollectionAssert.Contains(_receivedEvents, "BuildpackOptions");
         }
 
@@ -1341,7 +1346,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             await _sut.UpdateBuildpackOptions();
 
-            CollectionAssert.AreEquivalent(new List<string>(), _sut.BuildpackOptions);
+            CollectionAssert.AreEquivalent(new List<BuildpackListItem>(), _sut.BuildpackOptions);
         }
 
         [TestMethod]
@@ -1406,7 +1411,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             List<string> initialSelectedBps = _sut.SelectedBuildpacks.ToList();
             var initialBpsInManifestModel = _sut.ManifestModel.Applications[0].Buildpacks;
-            
+
             CollectionAssert.AreEquivalent(initialSelectedBps, initialBpsInManifestModel);
 
             _receivedEvents.Clear();

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -16,7 +17,10 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         private const string _fakeAppName = "fake app name";
         private const string _fakeProjName = "fake project name";
         private const string _fakeStack = "windows";
-        //private const string _fakeBuildpack = "junk";
+        private const string _fakeBuildpackName1 = "bp1";
+        private const string _fakeBuildpackName2 = "bp2";
+        private const string _fakeBuildpackName3 = "bp3";
+        private ObservableCollection<string> _fakeSelectedBuildpacks;
         private const string _fakeProjPath = "this\\is\\a\\fake\\path\\to\\a\\project\\directory";
         private const string _realPathToFakeDeploymentDir = "TestFakes";
         private const string FakeTargetFrameworkMoniker = "junk";
@@ -39,7 +43,11 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             Assert.IsTrue(Directory.Exists(_realPathToFakeDeploymentDir));
 
+            _fakeSelectedBuildpacks = new ObservableCollection<string> { _fakeBuildpackName1, _fakeBuildpackName2, _fakeBuildpackName3 };
+
             _sut = new DeploymentDialogViewModel(Services, _fakeProjName, _realPathToFakeDeploymentDir, FakeTargetFrameworkMoniker);
+
+            _sut.SelectedBuildpacks = _fakeSelectedBuildpacks;
 
             _receivedEvents = new List<string>();
             _sut.PropertyChanged += (sender, e) =>
@@ -276,6 +284,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 AppName = _fakeAppName,
                 SelectedOrg = _fakeOrg,
                 SelectedSpace = _fakeSpace,
+                SelectedBuildpacks = _fakeSelectedBuildpacks,
             };
 
             bool expectedFullFWFlag = true;
@@ -293,7 +302,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                false,
                                It.IsAny<string>(),
                                null,
-                               null))
+                               _fakeSelectedBuildpacks.Last()))
                 .ReturnsAsync(FakeSuccessDetailedResult);
 
             await _sut.StartDeployment();
@@ -318,7 +327,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                     false,
                                     _fakeProjName,
                                     null,
-                                    null))
+                                    _fakeSelectedBuildpacks.Last()))
                     .ReturnsAsync(FakeSuccessDetailedResult);
 
             _sut.AppName = _fakeAppName;
@@ -351,7 +360,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                     false,
                                     _fakeProjName,
                                     null,
-                                    null))
+                                    _fakeSelectedBuildpacks.Last()))
                     .ReturnsAsync(FakeSuccessDetailedResult);
 
             _sut.AppName = _fakeAppName;
@@ -365,11 +374,10 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
         [TestMethod]
         [TestCategory("StartDeployment")]
-        [DataRow("hwc_buildpack")]
-        [DataRow("myCustombuildpack")]
-        [DataRow("junk")]
-        public async Task StartDeploymentTask_PassesSelectedBuildpack_ForDeployment(string bp)
+        public async Task StartDeploymentTask_PassesTheLastItemInSelectedBuildpacks_ForDeployment()
         {
+            var fakeSelectedBuildpacks = new ObservableCollection<string> { "first item", "middle item", "last item" };
+
             MockCloudFoundryService.Setup(mock =>
                 mock.DeployAppAsync(_fakeCfInstance,
                                     _fakeOrg,
@@ -383,15 +391,15 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                     false,
                                     _fakeProjName,
                                     null,
-                                    bp))
+                                    fakeSelectedBuildpacks.Last()))
                     .ReturnsAsync(FakeSuccessDetailedResult);
 
             _sut.AppName = _fakeAppName;
             _sut.SelectedOrg = _fakeOrg;
             _sut.SelectedSpace = _fakeSpace;
             _sut.SelectedStack = "cflinuxfs3";
-            _sut.SelectedBuildpack = bp;
-            Assert.IsNotNull(_sut.SelectedBuildpack);
+            _sut.SelectedBuildpacks = fakeSelectedBuildpacks;
+            Assert.IsNotNull(_sut.SelectedBuildpacks);
 
             await _sut.StartDeployment();
         }
@@ -415,7 +423,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                     false,
                                     _fakeProjName,
                                     null,
-                                    null))
+                                    _fakeSelectedBuildpacks.Last()))
                     .ReturnsAsync(FakeSuccessDetailedResult);
 
             _sut.AppName = _fakeAppName;
@@ -448,7 +456,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                     isBinaryDeployment,
                                     _fakeProjName,
                                     null,
-                                    null))
+                                    _fakeSelectedBuildpacks.Last()))
                     .ReturnsAsync(FakeSuccessDetailedResult);
 
             _sut.AppName = _fakeAppName;
@@ -484,7 +492,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                     It.IsAny<bool>(),
                                     expectedProjectName,
                                     null,
-                                    null))
+                                    _fakeSelectedBuildpacks.Last()))
                     .ReturnsAsync(FakeSuccessDetailedResult);
 
             _sut.AppName = _fakeAppName;
@@ -521,7 +529,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                              false,
                              _fakeProjName,
                              null,
-                             null))
+                             _fakeSelectedBuildpacks.Last()))
                 .ReturnsAsync(FakeSuccessDetailedResult);
 
             await _sut.StartDeployment();
@@ -551,7 +559,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                false,
                                _fakeProjName,
                                null,
-                               null))
+                               _fakeSelectedBuildpacks.Last()))
                     .ReturnsAsync(FakeFailureDetailedResult);
 
             var expectedErrorTitle = $"{DeploymentDialogViewModel.DeploymentErrorMsg} {_fakeAppName}.";
@@ -598,7 +606,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                false,
                                _fakeProjName,
                                null,
-                               null))
+                               _fakeSelectedBuildpacks.Last()))
                     .ReturnsAsync(FakeFailureDetailedResult);
 
             var expectedErrorTitle = $"{DeploymentDialogViewModel.DeploymentErrorMsg} {_fakeAppName}.";
@@ -639,7 +647,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                false,
                                _fakeProjName,
                                null,
-                               null))
+                               _fakeSelectedBuildpacks.Last()))
                     .ReturnsAsync(invalidRefreshTokenFailure);
 
             MockTasExplorerViewModel.SetupSet(m => m.AuthenticationRequired = true).Verifiable();
@@ -678,7 +686,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                false,
                                _fakeProjName,
                                null,
-                               null))
+                               _fakeSelectedBuildpacks.Last()))
                     .ReturnsAsync(redundantErrorInfoResult);
 
             await _sut.StartDeployment();
@@ -1376,7 +1384,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
         [TestMethod]
         [TestCategory("UpdateBuildpackOptions")]
-        public async Task UpdateBuildpackOptions_DoesNotChangeBuildpackOptions_AndRaisesError_WhenQueryFails()
+        public async Task UpdateBuildpackOptions_SetsBuildpackOptionsToEmptyList_AndRaisesError_WhenQueryFails()
         {
             var fakeCf = new FakeCfInstanceViewModel(FakeCfInstance, Services);
             const string fakeFailureReason = "junk";
@@ -1386,13 +1394,94 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             MockCloudFoundryService.Setup(m => m.GetUniqueBuildpackNamesAsync(fakeCf.CloudFoundryInstance.ApiAddress, 1)).ReturnsAsync(fakeBuildpacksResponse);
 
-            var initialBuildpackOptions = _sut.BuildpackOptions;
             CollectionAssert.DoesNotContain(_receivedEvents, "BuildpackOptions");
 
             await _sut.UpdateBuildpackOptions();
 
-            Assert.AreEqual(initialBuildpackOptions, _sut.BuildpackOptions);
-            CollectionAssert.DoesNotContain(_receivedEvents, "BuildpackOptions");
+            CollectionAssert.AreEquivalent(new List<string>(), _sut.BuildpackOptions);
+        }
+
+        [TestMethod]
+        [TestCategory("AddToSelectedBuildpacks")]
+        public void AddToSelectedBuildpacks_AddsToSelectedBuildpacks_AndRaisesPropChangedEvent_WhenArgIsString()
+        {
+            string item = "new entry";
+            List<string> initialSelectedBps = _sut.SelectedBuildpacks.ToList();
+
+            CollectionAssert.DoesNotContain(initialSelectedBps, item);
+            CollectionAssert.DoesNotContain(_receivedEvents, "SelectedBuildpacks");
+
+            _sut.AddToSelectedBuildpacks(item);
+
+            var updatedSelectedBps = _sut.SelectedBuildpacks;
+
+            CollectionAssert.AreNotEquivalent(initialSelectedBps, updatedSelectedBps);
+            Assert.AreEqual(initialSelectedBps.Count + 1, updatedSelectedBps.Count);
+            CollectionAssert.Contains(updatedSelectedBps, item);
+
+            CollectionAssert.Contains(_receivedEvents, "SelectedBuildpacks");
+        }
+
+        [TestMethod]
+        [TestCategory("AddToSelectedBuildpacks")]
+        public void AddToSelectedBuildpacks_DoesNothing_WhenArgIsNotString()
+        {
+            object nonStringItem = new object();
+            List<string> initialSelectedBps = _sut.SelectedBuildpacks.ToList();
+
+            CollectionAssert.DoesNotContain(initialSelectedBps, nonStringItem);
+            CollectionAssert.DoesNotContain(_receivedEvents, "SelectedBuildpacks");
+
+            _sut.AddToSelectedBuildpacks(nonStringItem);
+
+            var updatedSelectedBps = _sut.SelectedBuildpacks;
+
+            CollectionAssert.AreEquivalent(initialSelectedBps, updatedSelectedBps);
+            CollectionAssert.DoesNotContain(_receivedEvents, "SelectedBuildpacks");
+        }
+
+        [TestMethod]
+        [TestCategory("RemoveFromSelectedBuildpacks")]
+        public void RemoveFromSelectedBuildpacks_RemovesFromSelectedBuildpacks_AndRaisesPropChangedEvent_WhenArgIsString()
+        {
+            string item = "existing entry";
+
+            _sut.SelectedBuildpacks = new System.Collections.ObjectModel.ObservableCollection<string>
+            {
+                item
+            };
+
+            List<string> initialSelectedBps = _sut.SelectedBuildpacks.ToList();
+            CollectionAssert.Contains(initialSelectedBps, item);
+
+            _receivedEvents.Clear();
+            CollectionAssert.DoesNotContain(_receivedEvents, "SelectedBuildpacks");
+
+            _sut.RemoveFromSelectedBuildpacks(item);
+
+            var updatedSelectedBps = _sut.SelectedBuildpacks;
+
+            CollectionAssert.AreNotEquivalent(initialSelectedBps, updatedSelectedBps);
+            Assert.AreEqual(initialSelectedBps.Count - 1, updatedSelectedBps.Count);
+            CollectionAssert.DoesNotContain(updatedSelectedBps, item);
+
+            CollectionAssert.Contains(_receivedEvents, "SelectedBuildpacks");
+        }
+
+        [TestMethod]
+        [TestCategory("RemoveFromSelectedBuildpacks")]
+        public void RemoveFromSelectedBuildpacks_DoesNothing_WhenArgIsNotString()
+        {
+            object nonStringItem = new object();
+
+            List<string> initialSelectedBps = _sut.SelectedBuildpacks.ToList();
+
+            _sut.RemoveFromSelectedBuildpacks(nonStringItem);
+
+            var updatedSelectedBps = _sut.SelectedBuildpacks;
+
+            CollectionAssert.AreEquivalent(initialSelectedBps, updatedSelectedBps);
+            CollectionAssert.DoesNotContain(_receivedEvents, "SelectedBuildpacks");
         }
     }
 

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -16,6 +16,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         private const string _fakeAppName = "fake app name";
         private const string _fakeProjName = "fake project name";
         private const string _fakeStack = "windows";
+        //private const string _fakeBuildpack = "junk";
         private const string _fakeProjPath = "this\\is\\a\\fake\\path\\to\\a\\project\\directory";
         private const string _realPathToFakeDeploymentDir = "TestFakes";
         private const string FakeTargetFrameworkMoniker = "junk";
@@ -270,8 +271,9 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                It.IsAny<StdOutDelegate>(),
                                It.IsAny<StdErrDelegate>(),
                                null,
-                               false, 
-                               It.IsAny<string>(), 
+                               false,
+                               It.IsAny<string>(),
+                               null,
                                null))
                 .ReturnsAsync(FakeSuccessDetailedResult);
 
@@ -296,6 +298,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                     null,
                                     false,
                                     _fakeProjName,
+                                    null,
                                     null))
                     .ReturnsAsync(FakeSuccessDetailedResult);
 
@@ -327,7 +330,8 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                     It.IsAny<StdErrDelegate>(),
                                     stack,
                                     false,
-                                    _fakeProjName, 
+                                    _fakeProjName,
+                                    null,
                                     null))
                     .ReturnsAsync(FakeSuccessDetailedResult);
 
@@ -339,7 +343,40 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             await _sut.StartDeployment();
         }
-        
+
+        [TestMethod]
+        [TestCategory("StartDeployment")]
+        [DataRow("hwc_buildpack")]
+        [DataRow("myCustombuildpack")]
+        [DataRow("junk")]
+        public async Task StartDeploymentTask_PassesSelectedBuildpack_ForDeployment(string bp)
+        {
+            MockCloudFoundryService.Setup(mock =>
+                mock.DeployAppAsync(_fakeCfInstance,
+                                    _fakeOrg,
+                                    _fakeSpace,
+                                    _fakeAppName,
+                                    _realPathToFakeDeploymentDir,
+                                    _defaultFullFWFlag,
+                                    It.IsAny<StdOutDelegate>(),
+                                    It.IsAny<StdErrDelegate>(),
+                                    "cflinuxfs3",
+                                    false,
+                                    _fakeProjName,
+                                    null,
+                                    bp))
+                    .ReturnsAsync(FakeSuccessDetailedResult);
+
+            _sut.AppName = _fakeAppName;
+            _sut.SelectedOrg = _fakeOrg;
+            _sut.SelectedSpace = _fakeSpace;
+            _sut.SelectedStack = "cflinuxfs3";
+            _sut.SelectedBuildpack = bp;
+            Assert.IsNotNull(_sut.SelectedBuildpack);
+
+            await _sut.StartDeployment();
+        }
+
         [TestMethod]
         [TestCategory("StartDeployment")]
         public async Task StartDeploymentTask_PassesDirectoryPath_ForDeployment()
@@ -357,7 +394,8 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                     It.IsAny<StdErrDelegate>(),
                                     _fakeStack,
                                     false,
-                                    _fakeProjName, 
+                                    _fakeProjName,
+                                    null,
                                     null))
                     .ReturnsAsync(FakeSuccessDetailedResult);
 
@@ -389,7 +427,8 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                     It.IsAny<StdErrDelegate>(),
                                     _fakeStack,
                                     isBinaryDeployment,
-                                    _fakeProjName, 
+                                    _fakeProjName,
+                                    null,
                                     null))
                     .ReturnsAsync(FakeSuccessDetailedResult);
 
@@ -424,7 +463,8 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                     It.IsAny<StdErrDelegate>(),
                                     _fakeStack,
                                     It.IsAny<bool>(),
-                                    expectedProjectName, 
+                                    expectedProjectName,
+                                    null,
                                     null))
                     .ReturnsAsync(FakeSuccessDetailedResult);
 
@@ -459,8 +499,9 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                              expectedStdOutCallback,
                              expectedStdErrCallback,
                              null,
-                             false, 
-                             _fakeProjName, 
+                             false,
+                             _fakeProjName,
+                             null,
                              null))
                 .ReturnsAsync(FakeSuccessDetailedResult);
 
@@ -488,8 +529,9 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                expectedStdOutCallback,
                                expectedStdErrCallback,
                                null,
-                               false, 
-                               _fakeProjName, 
+                               false,
+                               _fakeProjName,
+                               null,
                                null))
                     .ReturnsAsync(FakeFailureDetailedResult);
 
@@ -534,8 +576,9 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                expectedStdOutCallback,
                                expectedStdErrCallback,
                                null,
-                               false, 
-                               _fakeProjName, 
+                               false,
+                               _fakeProjName,
+                               null,
                                null))
                     .ReturnsAsync(FakeFailureDetailedResult);
 
@@ -575,7 +618,8 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                expectedStdErrCallback,
                                null,
                                false,
-                               _fakeProjName, 
+                               _fakeProjName,
+                               null,
                                null))
                     .ReturnsAsync(invalidRefreshTokenFailure);
 
@@ -614,6 +658,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                                null,
                                false,
                                _fakeProjName,
+                               null,
                                null))
                     .ReturnsAsync(redundantErrorInfoResult);
 

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -1257,30 +1257,6 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         }
 
         [TestMethod]
-        [TestCategory("BinaryDeployment")]
-        [TestCategory("DeploymentButtonLabel")]
-        public void BinaryDeployment_SetsDeploymentButtonLabelToPushSource_WhenSetToFalse()
-        {
-            _sut.DeploymentButtonLabel = "fake initial value";
-
-            _sut.BinaryDeployment = false;
-
-            Assert.AreEqual("Push app (from source)", _sut.DeploymentButtonLabel);
-        }
-
-        [TestMethod]
-        [TestCategory("BinaryDeployment")]
-        [TestCategory("DeploymentButtonLabel")]
-        public void BinaryDeployment_SetsDeploymentButtonLabelToPushBinaries_WhenSetToTrue()
-        {
-            _sut.DeploymentButtonLabel = "fake initial value";
-
-            _sut.BinaryDeployment = true;
-
-            Assert.AreEqual("Push app (from binaries)", _sut.DeploymentButtonLabel);
-        }
-
-        [TestMethod]
         [TestCategory("ToggleAdvancedOptions")]
         [DataRow(true, false)]
         [DataRow(false, true)]

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -1363,7 +1363,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             MockTasExplorerViewModel.SetupGet(m => m.TasConnection).Returns(fakeCf);
 
-            MockCloudFoundryService.Setup(m => m.GetBuildpackNamesAsync(fakeCf.CloudFoundryInstance.ApiAddress, 1)).ReturnsAsync(fakeBuildpacksResponse);
+            MockCloudFoundryService.Setup(m => m.GetUniqueBuildpackNamesAsync(fakeCf.CloudFoundryInstance.ApiAddress, 1)).ReturnsAsync(fakeBuildpacksResponse);
 
             Assert.AreNotEqual(fakeBuildpacksContent, _sut.BuildpackOptions);
             CollectionAssert.DoesNotContain(_receivedEvents, "BuildpackOptions");
@@ -1384,7 +1384,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             MockTasExplorerViewModel.SetupGet(m => m.TasConnection).Returns(fakeCf);
 
-            MockCloudFoundryService.Setup(m => m.GetBuildpackNamesAsync(fakeCf.CloudFoundryInstance.ApiAddress, 1)).ReturnsAsync(fakeBuildpacksResponse);
+            MockCloudFoundryService.Setup(m => m.GetUniqueBuildpackNamesAsync(fakeCf.CloudFoundryInstance.ApiAddress, 1)).ReturnsAsync(fakeBuildpacksResponse);
 
             var initialBuildpackOptions = _sut.BuildpackOptions;
             CollectionAssert.DoesNotContain(_receivedEvents, "BuildpackOptions");

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -1483,6 +1483,25 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             CollectionAssert.AreEquivalent(initialBpsInManifestModel, updatedBpsInManifestModel);
             CollectionAssert.DoesNotContain(_receivedEvents, "SelectedBuildpacks");
         }
+
+        [TestMethod]
+        [TestCategory("AppName")]
+        [TestCategory("ManifestModel")]
+        public void AppNameSetter_SetsValueInManifestModel()
+        {
+            var nameVal = "windows";
+            var initialStackInManifestModel = _sut.ManifestModel.Applications[0].Name;
+
+            Assert.AreNotEqual(nameVal, initialStackInManifestModel);
+
+            _sut.AppName = nameVal;
+
+            Assert.AreEqual(nameVal, _sut.AppName);
+            Assert.AreEqual(nameVal, _sut.ManifestModel.Applications[0].Name);
+            Assert.AreEqual(1, _receivedEvents.Count);
+            Assert.AreEqual("AppName", _receivedEvents[0]);
+        }
+
     }
 
     public class FakeOutputView : ViewModelTestSupport, IView

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -1029,6 +1029,26 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             Assert.IsNotNull(_sut.TasExplorerViewModel.TasConnection);
             MockThreadingService.Verify(m => m.StartTask(_sut.UpdateCfOrgOptions), Times.Once);
         }
+        
+        [TestMethod]
+        [TestCategory("OpenLoginView")]
+        public void OpenLoginView_UpdatesBuildpackOptions_WhenTasConnectionGetsSet()
+        {
+            MockTasExplorerViewModel.Setup(m => m.
+                OpenLoginView(null))
+                    .Callback(() =>
+                    {
+                        MockTasExplorerViewModel.SetupGet(m => m.TasConnection)
+                            .Returns(new CfInstanceViewModel(FakeCfInstance, null, Services));
+                    });
+
+            Assert.IsNull(_sut.TasExplorerViewModel.TasConnection);
+
+            _sut.OpenLoginView(null);
+
+            Assert.IsNotNull(_sut.TasExplorerViewModel.TasConnection);
+            MockThreadingService.Verify(m => m.StartTask(_sut.UpdateBuildpackOptions), Times.Once);
+        }
 
         [TestMethod]
         [TestCategory("IsLoggedIn")]

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -281,17 +281,15 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             _sut.AppName = _fakeAppName;
             _sut.SelectedSpace = _fakeSpace; // space must be set to faciliate lookup of parent org & grandparent cf
 
-            string expectedAppName = _sut.AppName;
+            AppManifest expectedManifest = _sut.ManifestModel;
             CloudFoundryInstance expectedCf = _sut.SelectedSpace.ParentOrg.ParentCf;
             CloudFoundryOrganization expectedOrg = _sut.SelectedSpace.ParentOrg;
             CloudFoundrySpace expectedSpace = _sut.SelectedSpace;
-            string expectedManifestPath = _sut.ManifestPath;
-            string expectedProjectPath = _sut.DeploymentDirectoryPath;
             StdOutDelegate expectedStdOutCallback = _sut.OutputViewModel.AppendLine;
             StdErrDelegate expectedStdErrCallback = _sut.OutputViewModel.AppendLine;
 
             MockCloudFoundryService.Setup(mock => mock.
-              DeployAppAsync(expectedAppName, expectedManifestPath, expectedProjectPath, expectedCf, expectedOrg, expectedSpace, expectedStdOutCallback, expectedStdErrCallback))
+              DeployAppAsync(expectedManifest, expectedCf, expectedOrg, expectedSpace, expectedStdOutCallback, expectedStdErrCallback))
                 .ReturnsAsync(FakeSuccessDetailedResult);
 
             _sut.AppName = _fakeAppName;
@@ -311,17 +309,15 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             _sut.AppName = _fakeAppName;
             _sut.SelectedSpace = _fakeSpace; // space must be set to faciliate lookup of parent org & grandparent cf
 
-            string expectedAppName = _sut.AppName;
+            AppManifest expectedManifest = _sut.ManifestModel;
             CloudFoundryInstance expectedCf = _sut.SelectedSpace.ParentOrg.ParentCf;
             CloudFoundryOrganization expectedOrg = _sut.SelectedSpace.ParentOrg;
             CloudFoundrySpace expectedSpace = _sut.SelectedSpace;
-            string expectedManifestPath = _sut.ManifestPath;
-            string expectedProjectPath = _sut.DeploymentDirectoryPath;
             StdOutDelegate expectedStdOutCallback = _sut.OutputViewModel.AppendLine;
             StdErrDelegate expectedStdErrCallback = _sut.OutputViewModel.AppendLine;
 
             MockCloudFoundryService.Setup(mock => mock.
-              DeployAppAsync(expectedAppName, expectedManifestPath, expectedProjectPath, expectedCf, expectedOrg, expectedSpace, expectedStdOutCallback, expectedStdErrCallback))
+              DeployAppAsync(expectedManifest, expectedCf, expectedOrg, expectedSpace, expectedStdOutCallback, expectedStdErrCallback))
                 .ReturnsAsync(FakeFailureDetailedResult);
 
             var expectedErrorTitle = $"{DeploymentDialogViewModel.DeploymentErrorMsg} {_fakeAppName}.";
@@ -351,20 +347,18 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             _sut.AppName = _fakeAppName;
             _sut.SelectedSpace = _fakeSpace; // space must be set to faciliate lookup of parent org & grandparent cf
 
-            string expectedAppName = _sut.AppName;
+            AppManifest expectedManifest = _sut.ManifestModel;
             CloudFoundryInstance expectedCf = _sut.SelectedSpace.ParentOrg.ParentCf;
             CloudFoundryOrganization expectedOrg = _sut.SelectedSpace.ParentOrg;
             CloudFoundrySpace expectedSpace = _sut.SelectedSpace;
-            string expectedManifestPath = _sut.ManifestPath;
-            string expectedProjectPath = _sut.DeploymentDirectoryPath;
             StdOutDelegate expectedStdOutCallback = _sut.OutputViewModel.AppendLine;
             StdErrDelegate expectedStdErrCallback = _sut.OutputViewModel.AppendLine;
 
             string expectedErrorTitle = $"{DeploymentDialogViewModel.DeploymentErrorMsg} {_fakeAppName}.";
             string expectedErrorMsg = $"{FakeFailureDetailedResult.Explanation}";
-
+            
             MockCloudFoundryService.Setup(mock => mock.
-              DeployAppAsync(expectedAppName, expectedManifestPath, expectedProjectPath, expectedCf, expectedOrg, expectedSpace, expectedStdOutCallback, expectedStdErrCallback))
+              DeployAppAsync(expectedManifest, expectedCf, expectedOrg, expectedSpace, expectedStdOutCallback, expectedStdErrCallback))
                 .ReturnsAsync(FakeFailureDetailedResult);
 
             await _sut.StartDeployment();
@@ -381,20 +375,17 @@ namespace Tanzu.Toolkit.ViewModels.Tests
                 FailureType = FailureType.InvalidRefreshToken
             };
             
-            _sut.AppName = _fakeAppName;
             _sut.SelectedSpace = _fakeSpace; // space must be set to faciliate lookup of parent org & grandparent cf
 
-            string expectedAppName = _sut.AppName;
+            AppManifest expectedManifest = _sut.ManifestModel;
             CloudFoundryInstance expectedCf = _sut.SelectedSpace.ParentOrg.ParentCf;
             CloudFoundryOrganization expectedOrg = _sut.SelectedSpace.ParentOrg;
             CloudFoundrySpace expectedSpace = _sut.SelectedSpace;
-            string expectedManifestPath = _sut.ManifestPath;
-            string expectedProjectPath = _sut.DeploymentDirectoryPath;
             StdOutDelegate expectedStdOutCallback = _sut.OutputViewModel.AppendLine;
             StdErrDelegate expectedStdErrCallback = _sut.OutputViewModel.AppendLine;
 
             MockCloudFoundryService.Setup(mock => mock.
-              DeployAppAsync(expectedAppName, expectedManifestPath, expectedProjectPath, expectedCf, expectedOrg, expectedSpace, expectedStdOutCallback, expectedStdErrCallback))
+              DeployAppAsync(expectedManifest, expectedCf, expectedOrg, expectedSpace, expectedStdOutCallback, expectedStdErrCallback))
                 .ReturnsAsync(invalidRefreshTokenFailure);
 
             MockTasExplorerViewModel.SetupSet(m => m.AuthenticationRequired = true).Verifiable();
@@ -416,17 +407,15 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             _sut.AppName = _fakeAppName;
             _sut.SelectedSpace = _fakeSpace; // space must be set to faciliate lookup of parent org & grandparent cf
 
-            string expectedAppName = _sut.AppName;
+            AppManifest expectedManifest = _sut.ManifestModel;
             CloudFoundryInstance expectedCf = _sut.SelectedSpace.ParentOrg.ParentCf;
             CloudFoundryOrganization expectedOrg = _sut.SelectedSpace.ParentOrg;
             CloudFoundrySpace expectedSpace = _sut.SelectedSpace;
-            string expectedManifestPath = _sut.ManifestPath;
-            string expectedProjectPath = _sut.DeploymentDirectoryPath;
             StdOutDelegate expectedStdOutCallback = _sut.OutputViewModel.AppendLine;
             StdErrDelegate expectedStdErrCallback = _sut.OutputViewModel.AppendLine;
 
             MockCloudFoundryService.Setup(mock => mock.
-              DeployAppAsync(expectedAppName, expectedManifestPath, expectedProjectPath, expectedCf, expectedOrg, expectedSpace, expectedStdOutCallback, expectedStdErrCallback))
+              DeployAppAsync(expectedManifest, expectedCf, expectedOrg, expectedSpace, expectedStdOutCallback, expectedStdErrCallback))
                 .ReturnsAsync(redundantErrorInfoResult);
 
             await _sut.StartDeployment();
@@ -1163,6 +1152,8 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         [TestCategory("SelectedStack")]
         public void SelectedStackSetter_SetsValue_WhenValueExistsInStackOptions()
         {
+            Assert.Fail("TODO: add tests that ensure the ManifestModel gets updated when 'selectedXYZ' properties change");
+
             var stackVal = "windows";
 
             Assert.IsTrue(_sut.StackOptions.Contains(stackVal));

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -1439,6 +1439,27 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             CollectionAssert.AreEquivalent(initialSelectedBps, updatedSelectedBps);
             CollectionAssert.DoesNotContain(_receivedEvents, "SelectedBuildpacks");
         }
+        
+        [TestMethod]
+        [TestCategory("AddToSelectedBuildpacks")]
+        public void AddToSelectedBuildpacks_DoesNothing_WhenStringAlreadyExistsInSelectedBuildpacks()
+        {
+            var item = "junk";
+            _sut.SelectedBuildpacks = new ObservableCollection<string> { item, "extra", "stuff" };
+            List<string> initialSelectedBps = _sut.SelectedBuildpacks.ToList();
+
+            _receivedEvents.Clear();
+
+            CollectionAssert.Contains(initialSelectedBps, item);
+            CollectionAssert.DoesNotContain(_receivedEvents, "SelectedBuildpacks");
+
+            _sut.AddToSelectedBuildpacks(item);
+
+            var updatedSelectedBps = _sut.SelectedBuildpacks;
+
+            CollectionAssert.AreEquivalent(initialSelectedBps, updatedSelectedBps);
+            CollectionAssert.DoesNotContain(_receivedEvents, "SelectedBuildpacks");
+        }
 
         [TestMethod]
         [TestCategory("RemoveFromSelectedBuildpacks")]

--- a/src/ViewModels/test/Tanzu.Toolkit.ViewModels.Tests.csproj
+++ b/src/ViewModels/test/Tanzu.Toolkit.ViewModels.Tests.csproj
@@ -32,6 +32,9 @@
     <None Update="TestFakes\fake-invalid-manifest.yml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TestFakes\fake-multi-buildpack-manifest.yml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TestFakes\fake-manifest.yml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/ViewModels/test/TestFakes/fake-multi-buildpack-manifest.yml
+++ b/src/ViewModels/test/TestFakes/fake-multi-buildpack-manifest.yml
@@ -3,3 +3,5 @@
   stack: windows
   buildpacks:
   - my_cool_bp
+  - another_buildpack
+  - final_buildpack

--- a/src/ViewModels/test/ViewModelTestSupport.cs
+++ b/src/ViewModels/test/ViewModelTestSupport.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Serilog;
@@ -9,6 +10,7 @@ using Tanzu.Toolkit.Services.CloudFoundry;
 using Tanzu.Toolkit.Services.CommandProcess;
 using Tanzu.Toolkit.Services.Dialog;
 using Tanzu.Toolkit.Services.ErrorDialog;
+using Tanzu.Toolkit.Services.File;
 using Tanzu.Toolkit.Services.Logging;
 using Tanzu.Toolkit.Services.Threading;
 using Tanzu.Toolkit.Services.ViewLocator;
@@ -27,6 +29,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         protected Mock<ILogger> MockLogger { get; set; }
         protected Mock<IThreadingService> MockThreadingService { get; set; }
         protected Mock<IUiDispatcherService> MockUiDispatcherService { get; set; }
+        protected Mock<IFileService> MockFileService { get; set; }
         protected Mock<ITasExplorerViewModel> MockTasExplorerViewModel { get; set; }
 
         protected const string FakeCfName = "fake cf name";
@@ -51,6 +54,10 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         protected static readonly DetailedResult FakeSuccessDetailedResult = new DetailedResult(true, null, FakeSuccessCmdResult);
         protected static readonly DetailedResult FakeFailureDetailedResult = new DetailedResult(false, "junk error", FakeFailureCmdResult);
 
+        internal string[] sampleManifestLines = File.ReadAllLines("TestFakes//fake-manifest.yml");
+        internal string[] sampleInvalidManifestLines = File.ReadAllLines("TestFakes//fake-invalid-manifest.yml");
+        internal string[] multiBuildpackManifestLines = File.ReadAllLines("TestFakes//fake-multi-buildpack-manifest.yml");
+
         protected ViewModelTestSupport()
         {
             RenewMockServices();
@@ -67,6 +74,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             MockLoggingService = new Mock<ILoggingService>();
             MockThreadingService = new Mock<IThreadingService>();
             MockUiDispatcherService = new Mock<IUiDispatcherService>();
+            MockFileService = new Mock<IFileService>();
             MockTasExplorerViewModel = new Mock<ITasExplorerViewModel>();
 
             MockLogger = new Mock<ILogger>();
@@ -80,6 +88,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             services.AddSingleton(MockThreadingService.Object);
             services.AddSingleton(MockUiDispatcherService.Object);
             services.AddSingleton(MockTasExplorerViewModel.Object);
+            services.AddSingleton(MockFileService.Object);
 
             Services = services.BuildServiceProvider();
         }

--- a/src/ViewModels/test/ViewModelTestSupport.cs
+++ b/src/ViewModels/test/ViewModelTestSupport.cs
@@ -14,6 +14,7 @@ using Tanzu.Toolkit.Services.File;
 using Tanzu.Toolkit.Services.Logging;
 using Tanzu.Toolkit.Services.Threading;
 using Tanzu.Toolkit.Services.ViewLocator;
+using static Tanzu.Toolkit.Services.OutputHandler.OutputHandler;
 
 namespace Tanzu.Toolkit.ViewModels.Tests
 {
@@ -53,6 +54,11 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
         protected static readonly DetailedResult FakeSuccessDetailedResult = new DetailedResult(true, null, FakeSuccessCmdResult);
         protected static readonly DetailedResult FakeFailureDetailedResult = new DetailedResult(false, "junk error", FakeFailureCmdResult);
+
+        protected static readonly string _fakeProjectPath = "this\\is\\a\\fake\\path\\to\\a\\project\\directory";
+        protected static readonly string _fakeManifestPath = "this\\is\\a\\fake\\path\\to\\a\\manifest";
+        protected static readonly StdOutDelegate _fakeOutCallback = content => { };
+        protected static readonly StdErrDelegate _fakeErrCallback = content => { };
 
         internal string[] sampleManifestLines = File.ReadAllLines("TestFakes//fake-manifest.yml");
         internal string[] sampleInvalidManifestLines = File.ReadAllLines("TestFakes//fake-invalid-manifest.yml");

--- a/src/ViewModels/test/ViewModelTestSupport.cs
+++ b/src/ViewModels/test/ViewModelTestSupport.cs
@@ -64,6 +64,124 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         internal string[] sampleInvalidManifestLines = File.ReadAllLines("TestFakes//fake-invalid-manifest.yml");
         internal string[] multiBuildpackManifestLines = File.ReadAllLines("TestFakes//fake-multi-buildpack-manifest.yml");
 
+        protected AppManifest _fakeManifestModel = new AppManifest
+        {
+            Version = 1,
+            Applications = new List<AppConfig>
+                {
+                    new AppConfig
+                    {
+                        Name = "app1",
+                        Buildpacks = new List<string>
+                        {
+                            "ruby_buildpack",
+                            "java_buildpack",
+                            "my_cool_buildpack",
+                        },
+                        Env = new Dictionary<string, string>
+                        {
+                            {"VAR1", "value1" },
+                            {"VAR2", "value2" },
+                        },
+                        Routes = new List<RouteConfig>
+                        {
+                            new RouteConfig
+                            {
+                                Route = "route.example.com",
+                            },
+                            new RouteConfig
+                            {
+                                Route = "another-route.example.com",
+                                Protocol = "http2"
+                            },
+                        },
+                        Services = new List<string> {
+                            "my-service1",
+                            "my-service2",
+                        },
+                        Stack = "cflinuxfs3",
+                        Metadata = new MetadataConfig
+                        {
+                            Annotations = new Dictionary<string, string>
+                            {
+                                { "contact", "bob@example.com jane@example.com" },
+                            },
+                            Labels = new Dictionary<string, string>
+                            {
+                                { "sensitive", "true" },
+                            },
+                        },
+                        Processes = new List<ProcessConfig>
+                        {
+                            new ProcessConfig
+                            {
+                                Type = "web",
+                                Command = "start-web.sh",
+                                DiskQuota = "512M",
+                                HealthCheckHttpEndpoint = "/healthcheck",
+                                HealthCheckType = "http",
+                                HealthCheckInvocationTimeout = 10,
+                                Instances = 3,
+                                Memory = "500M",
+                                Timeout = 10,
+                            },
+                            new ProcessConfig
+                            {
+                                Type = "worker",
+                                Command = "start-worker.sh",
+                                DiskQuota = "1G",
+                                HealthCheckType = "process",
+                                Instances = 2,
+                                Memory = "256M",
+                                Timeout = 15,
+                            },
+                        },
+                        Path = "some//fake//path",
+                    },
+                    new AppConfig
+                    {
+                        Name = "app2",
+                        Env = new Dictionary<string, string>
+                        {
+                            { "VAR1", "value1" },
+                        },
+                        Processes = new List<ProcessConfig>
+                        {
+                            new ProcessConfig
+                            {
+                                Type = "web",
+                                Instances = 1,
+                                Memory = "256M",
+                            },
+                        },
+                        Sidecars = new List<SidecarConfig>
+                        {
+                            new SidecarConfig
+                            {
+                                Name = "authenticator",
+                                ProcessTypes = new List<string>
+                                {
+                                    "web",
+                                    "worker",
+                                },
+                                Command = "bundle exec run-authenticator",
+                                Memory = "800M",
+                            },
+                            new SidecarConfig
+                            {
+                                Name = "upcaser",
+                                ProcessTypes = new List<string>
+                                {
+                                    "worker",
+                                },
+                                Command = "./tr-server",
+                                Memory = "2G",
+                            }
+                        }
+                    }
+                }
+        };
+
         protected ViewModelTestSupport()
         {
             RenewMockServices();

--- a/src/VisualStudioExtension/src/Commands/OpenLogsCommand.cs
+++ b/src/VisualStudioExtension/src/Commands/OpenLogsCommand.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Shell;
 using Serilog;
 using Tanzu.Toolkit.Services.Dialog;
 using Tanzu.Toolkit.Services.ErrorDialog;
-using Tanzu.Toolkit.Services.FileLocator;
+using Tanzu.Toolkit.Services.File;
 using Tanzu.Toolkit.Services.Logging;
 using Task = System.Threading.Tasks.Task;
 
@@ -37,7 +37,7 @@ namespace Tanzu.Toolkit.VisualStudio.Commands
         private readonly AsyncPackage _package;
 
         public static DTE2 Dte { get; private set; }
-        private static IFileLocatorService _fileLocatorService;
+        private static IFileService _fileService;
         private static ILogger _logger;
         private static IErrorDialog _dialogService;
 
@@ -92,12 +92,12 @@ namespace Tanzu.Toolkit.VisualStudio.Commands
             Instance = new OpenLogsCommand(package, commandService);
 
             Dte = await package.GetServiceAsync(typeof(DTE)) as DTE2;
-            _fileLocatorService = services.GetRequiredService<IFileLocatorService>();
+            _fileService = services.GetRequiredService<IFileService>();
             _dialogService = services.GetRequiredService<IErrorDialog>();
             var logSvc = services.GetRequiredService<ILoggingService>();
              
             Assumes.Present(Dte);
-            Assumes.Present(_fileLocatorService);
+            Assumes.Present(_fileService);
             Assumes.Present(_dialogService);
             Assumes.Present(logSvc);
 
@@ -115,7 +115,7 @@ namespace Tanzu.Toolkit.VisualStudio.Commands
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            var logFilePath = _fileLocatorService.PathToLogsFile;
+            var logFilePath = _fileService.PathToLogsFile;
             var tmpFilePath = GenerateTmpFileName(logFilePath);
 
             var alreadyOpen = Dte.ItemOperations.IsFileOpen(tmpFilePath);

--- a/src/VisualStudioExtension/src/TanzuToolkitForVisualStudioPackage.cs
+++ b/src/VisualStudioExtension/src/TanzuToolkitForVisualStudioPackage.cs
@@ -12,7 +12,7 @@ using Tanzu.Toolkit.Services.CloudFoundry;
 using Tanzu.Toolkit.Services.CommandProcess;
 using Tanzu.Toolkit.Services.Dialog;
 using Tanzu.Toolkit.Services.ErrorDialog;
-using Tanzu.Toolkit.Services.FileLocator;
+using Tanzu.Toolkit.Services.File;
 using Tanzu.Toolkit.Services.Logging;
 using Tanzu.Toolkit.Services.Threading;
 using Tanzu.Toolkit.Services.ViewLocator;
@@ -117,7 +117,7 @@ namespace Tanzu.Toolkit.VisualStudio
             services.AddSingleton<IViewLocatorService, WpfViewLocatorService>();
             services.AddSingleton<IDialogService, WpfDialogService>();
             services.AddSingleton<ICfCliService>(provider => new CfCliService(assemblyBasePath, provider));
-            services.AddSingleton<IFileLocatorService>(new FileLocatorService(assemblyBasePath));
+            services.AddSingleton<IFileService>(new FileService(assemblyBasePath));
             services.AddSingleton<ILoggingService, LoggingService>();
             services.AddSingleton<IViewService, VsToolWindowService>();
             services.AddSingleton<IThreadingService, ThreadingService>();

--- a/src/WpfViews/src/Converters/ListToStringConverter.cs
+++ b/src/WpfViews/src/Converters/ListToStringConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Windows.Data;
+
+namespace Tanzu.Toolkit.WpfViews.Converters
+{
+    public class ListToStringConverter : IValueConverter
+    {
+        public string EmptyListMessage { get; set; }
+
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            var valueList = value as ObservableCollection<string>;
+
+            if (valueList == null) return string.Empty;
+
+            if (valueList.Count == 0) return EmptyListMessage;
+
+            return string.Join(", ", valueList);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/WpfViews/src/Converters/VisibilityConverter.cs
+++ b/src/WpfViews/src/Converters/VisibilityConverter.cs
@@ -8,7 +8,6 @@ namespace Tanzu.Toolkit.WpfViews.Converters
     public class VisibilityConverter : IValueConverter
     {
         public bool Reversed { get; set; }
-
         public bool ReserveSpace { get; set; }
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/WpfViews/src/DeploymentDialogView.xaml
+++ b/src/WpfViews/src/DeploymentDialogView.xaml
@@ -330,11 +330,11 @@
                     </ListView.ItemContainerStyle>
                     <ListView.ItemTemplate>
                         <DataTemplate>
-                            <CheckBox 
-                           Content="{Binding}" 
-                           IsChecked="{Binding IsChecked}"
-                           Checked="CheckBox_Checked"
-                           Unchecked="CheckBox_Unchecked"/>
+                            <CheckBox
+                                Content="{Binding Name}"
+                                IsChecked="{Binding IsSelected}"
+                                Checked="CheckBox_Checked"
+                                Unchecked="CheckBox_Unchecked"/>
                         </DataTemplate>
                     </ListView.ItemTemplate>
                 </ListView>

--- a/src/WpfViews/src/DeploymentDialogView.xaml
+++ b/src/WpfViews/src/DeploymentDialogView.xaml
@@ -299,16 +299,30 @@
                     ToolTip="{Binding SelectedBuildpacks, Converter={StaticResource SelectedBuildpacksStringListConverter}}"
                     IsEnabled="{Binding IsLoggedIn}"/>
 
-                <ListBox
+                <ListView
+                    ItemsSource="{Binding BuildpackOptions}"
                     Grid.Row="2"
                     Grid.Column="1"
                     Margin="0,4"
                     MaxHeight="128"
-                    SelectionMode="Multiple"
                     Visibility="{Binding IsLoggedIn, Converter={StaticResource ExpansionConverter}}"
-                    ItemsSource="{Binding BuildpackOptions}"
-                    IsEnabled="{Binding IsLoggedIn}"
-                    SelectionChanged="ListBox_SelectionChanged"/>
+                    SelectionMode="Multiple"
+                    IsEnabled="{Binding IsLoggedIn}">
+                    <ListView.ItemContainerStyle>
+                        <Style TargetType="ListViewItem">
+                            <Setter Property="Focusable" Value="false"/>
+                        </Style>
+                    </ListView.ItemContainerStyle>
+                    <ListView.ItemTemplate>
+                    <DataTemplate>
+                       <CheckBox 
+                           Content="{Binding}" 
+                           IsChecked="{Binding IsChecked}"
+                           Checked="CheckBox_Checked"
+                           Unchecked="CheckBox_Unchecked"/>
+                    </DataTemplate>
+                  </ListView.ItemTemplate>
+                </ListView>
             </StackPanel>
 
 

--- a/src/WpfViews/src/DeploymentDialogView.xaml
+++ b/src/WpfViews/src/DeploymentDialogView.xaml
@@ -314,13 +314,22 @@
                     </Button>
                 </Grid>
 
+                <StackPanel Visibility="{Binding IsLoggedIn, Converter={StaticResource Visibility}}">
+                <TextBlock
+                    Text="Loading Buildpacks..."
+                    Grid.Row="2"
+                    Grid.Column="1"
+                    Margin="4,0,0,4"
+                    FontStyle="Italic"
+                    Visibility="{Binding BuildpacksLoading, Converter={StaticResource Visibility}}"/>
+
                 <ListView
                     ItemsSource="{Binding BuildpackOptions}"
                     Grid.Row="2"
                     Grid.Column="1"
                     Margin="0,4"
                     MaxHeight="128"
-                    Visibility="{Binding IsLoggedIn, Converter={StaticResource ExpansionConverter}}"
+                    Visibility="{Binding BuildpacksLoading, Converter={StaticResource InverseVisibility}}"
                     SelectionMode="Multiple"
                     IsEnabled="{Binding IsLoggedIn}">
                     <ListView.ItemContainerStyle>
@@ -338,6 +347,7 @@
                         </DataTemplate>
                     </ListView.ItemTemplate>
                 </ListView>
+                </StackPanel>
             </StackPanel>
 
 

--- a/src/WpfViews/src/DeploymentDialogView.xaml
+++ b/src/WpfViews/src/DeploymentDialogView.xaml
@@ -317,6 +317,7 @@
                 <StackPanel Visibility="{Binding IsLoggedIn, Converter={StaticResource Visibility}}">
                 <TextBlock
                     Text="Loading Buildpacks..."
+                    Foreground="Gray"
                     Grid.Row="2"
                     Grid.Column="1"
                     Margin="4,0,0,4"

--- a/src/WpfViews/src/DeploymentDialogView.xaml
+++ b/src/WpfViews/src/DeploymentDialogView.xaml
@@ -9,7 +9,7 @@
         Name="DeploymentDialogViewElement"
         Title="Deploy to Tanzu Application Service"
         Icon="Resources/tas_16px.png"
-        Width="500"
+        Width="600"
         BorderBrush="{Binding ElementName=DeploymentDialogViewElement, Path=Foreground }"
         BorderThickness="1"
         ResizeMode="NoResize"
@@ -42,7 +42,7 @@
             <TextBlock FontSize="24" Text="Push to Tanzu Application Service" Margin="4" Grid.Row="0" Grid.Column="1"/>
         </StackPanel>
 
-        <Grid x:Name="MainContent" Width="414" VerticalAlignment="Top" Margin="8,8,8,0" DockPanel.Dock="Top">
+        <Grid x:Name="MainContent" Width="500" VerticalAlignment="Top" Margin="8,8,8,0" DockPanel.Dock="Top">
             <Grid.RowDefinitions>
                 <!--ROW 0-->
                 <RowDefinition Height="42"></RowDefinition>
@@ -206,7 +206,7 @@
         <Grid
             Name="HiddenContent"
             Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}"
-            Width="414"
+            Width="500"
             VerticalAlignment="Top"
             Margin="8,8,8,0"
             DockPanel.Dock="Top">
@@ -270,7 +270,7 @@
             <!--HIDDEN GRID ROW 2-->
             <TextBlock
                 VerticalAlignment="Top"
-                Margin="0,4"
+                Margin="0,6,0,0"
                 Grid.Row="2"
                 Grid.Column="0"
                 Text="Buildpack:"/>
@@ -279,10 +279,40 @@
                 Grid.Row="2"
                 Grid.Column="1">
 
-                <Label
-                    Content="{Binding SelectedBuildpacks, Converter={StaticResource SelectedBuildpacksStringListConverter}}"
-                    ToolTip="{Binding SelectedBuildpacks, Converter={StaticResource SelectedBuildpacksStringListConverter}}"
-                    IsEnabled="{Binding IsLoggedIn}"/>
+                <Grid Grid.Row="2" Grid.Column="1">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="32"></RowDefinition>
+                    </Grid.RowDefinitions>
+
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="32"/>
+                    </Grid.ColumnDefinitions>
+
+                    <Label
+                        Content="{Binding SelectedBuildpacks, Converter={StaticResource SelectedBuildpacksStringListConverter}}"
+                        ToolTip="{Binding SelectedBuildpacks, Converter={StaticResource SelectedBuildpacksStringListConverter}}"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        IsEnabled="{Binding IsLoggedIn}"/>
+
+                    <Button
+                        Grid.Column="1"
+                        MinHeight="0"
+                        MinWidth="0"
+                        IsEnabled="{Binding IsLoggedIn}"
+                        Command="{Binding ElementName=DeploymentDialogViewElement, Path=ClearBuildpackSelectionCommand}"
+                        VerticalAlignment="Center">
+                        <Button.Template>
+                            <ControlTemplate TargetType="Button">
+                                <ContentPresenter />
+                            </ControlTemplate>
+                        </Button.Template>
+                        <TextBlock
+                            Text="Clear"
+                            FontStyle="Italic"/>
+                    </Button>
+                </Grid>
 
                 <ListView
                     ItemsSource="{Binding BuildpackOptions}"

--- a/src/WpfViews/src/DeploymentDialogView.xaml
+++ b/src/WpfViews/src/DeploymentDialogView.xaml
@@ -6,26 +6,20 @@
         xmlns:converters="clr-namespace:Tanzu.Toolkit.WpfViews.Converters"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
         xmlns:wpfviews="clr-namespace:Tanzu.Toolkit.VisualStudio.WpfViews"
-        mc:Ignorable="d"
         Name="DeploymentDialogViewElement"
         Title="Deploy to Tanzu Application Service"
         Icon="Resources/tas_16px.png"
         Width="500"
-        Height="335"
         BorderBrush="{Binding ElementName=DeploymentDialogViewElement, Path=Foreground }"
         BorderThickness="1"
         ResizeMode="NoResize"
         WindowStyle="None"
-        d:DesignHeight="500" d:DesignWidth="800">
+        SizeToContent="Height">
 
     <Window.Resources>
-        <sys:Double x:Key="collapsedWindowHeight">335</sys:Double>
-        <sys:Double x:Key="expandedWindowHeight">430</sys:Double>
-        <sys:Double x:Key="collapsedGridBodyHeight">210</sys:Double>
-        <sys:Double x:Key="expandedGridBodyHeight">320</sys:Double>
-
         <converters:VisibilityConverter x:Key="Visibility" />
         <converters:VisibilityConverter x:Key="InverseVisibility" Reversed="True"/>
+        <converters:VisibilityConverter x:Key="ExpansionConverter" ReserveSpace="False" />
 
         <Style x:Key="RoundedButtonStyle" TargetType="{x:Type Button}">
             <Setter Property="Template">
@@ -46,7 +40,7 @@
             <TextBlock FontSize="24" Text="Push to Tanzu Application Service" Margin="4" Grid.Row="0" Grid.Column="1"/>
         </StackPanel>
 
-        <Grid x:Name="GridBody" Width="414" Height="{StaticResource collapsedGridBodyHeight}" VerticalAlignment="Top" Margin="8,8,8,0" DockPanel.Dock="Top">
+        <Grid x:Name="GridBody" Width="414" VerticalAlignment="Top" Margin="8,8,8,0" DockPanel.Dock="Top">
             <Grid.RowDefinitions>
                 <!--ROW 0-->
                 <RowDefinition Height="42"></RowDefinition>
@@ -63,11 +57,13 @@
                 <!--ROW 6-->
                 <RowDefinition Height="32"></RowDefinition>
                 <!--ROW 7-->
-                <RowDefinition Height="32"></RowDefinition>
+                <RowDefinition Height="auto"></RowDefinition>
                 <!--ROW 8-->
-                <RowDefinition Height="32"></RowDefinition>
+                <RowDefinition Height="auto"></RowDefinition>
                 <!--ROW 9-->
-                <RowDefinition Height="32"></RowDefinition>
+                <RowDefinition Height="auto"></RowDefinition>
+                <!--ROW 10-->
+                <RowDefinition Height="auto"></RowDefinition>
             </Grid.RowDefinitions>
 
             <Grid.ColumnDefinitions>
@@ -97,7 +93,8 @@
                    Visibility="{Binding IsLoggedIn, Converter={StaticResource Visibility}}"/>
 
             <!--ROW 1-->
-            <!--Intentionally empty-->
+            <Separator Grid.Row="1"
+                       Visibility="Hidden"/>
 
             <!--ROW 2-->
             <TextBlock Grid.Row="2" Text="App Manifest:" VerticalAlignment="Center"/>
@@ -212,14 +209,20 @@
             </Button>
 
             <!--ROW 7-->
-            <Separator Grid.Row="7" Grid.ColumnSpan="2" Visibility="{Binding Expanded, Converter={StaticResource Visibility}}"/>
+            <Separator Grid.Row="7" Grid.ColumnSpan="2" 
+                       Margin="0,12"
+                       Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}"/>
 
             <!--ROW 8-->
-            <TextBlock Grid.Row="8" Text="Directory to Push:" VerticalAlignment="Center" ToolTip="Path to app directory or to a zip file of the contents of the app directory"/>
+            <TextBlock Grid.Row="8" 
+                       Text="Directory to Push:" 
+                       VerticalAlignment="Center" 
+                       Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}"
+                       ToolTip="Path to app directory or to a zip file of the contents of the app directory"/>
 
-            <Grid Grid.Row="8" Grid.Column="1" VerticalAlignment="Center">
+            <Grid Grid.Row="8" Grid.Column="1" VerticalAlignment="Center" Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}">
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="24"></RowDefinition>
+                    <RowDefinition Height="32"></RowDefinition>
                 </Grid.RowDefinitions>
 
                 <Grid.ColumnDefinitions>
@@ -236,7 +239,10 @@
                     ToolTip="{Binding DirectoryPathLabel}"/>
 
                 <Button 
-                    MaxWidth="32" MinWidth="32" Padding="0"
+                    MaxWidth="32" 
+                    MinWidth="32" 
+                    Height="24"
+                    Padding="0"
                     Grid.Row="0"
                     Grid.Column="1"
                     IsEnabled="{Binding IsLoggedIn}"
@@ -248,20 +254,34 @@
             </Grid>
 
             <!-- ROW 9-->
-            <StackPanel VerticalAlignment="Center" Grid.Row="9" >
-                <TextBlock VerticalAlignment="Center" Text="Stack:"/>
+            <StackPanel VerticalAlignment="Center" Grid.Row="9" Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}">
+                <TextBlock VerticalAlignment="Center" Text="Buildpack:" />
             </StackPanel>
 
             <ComboBox Grid.Row="9" Grid.Column="1" Margin="0,4" 
+                      Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}"
+                      ItemsSource="{Binding BuildpackOptions}" 
+                      IsEnabled="{Binding IsLoggedIn}"
+                      SelectedItem="{Binding SelectedBuildpack}">
+            </ComboBox>
+            
+            <!-- ROW 10-->
+            <StackPanel VerticalAlignment="Center" Grid.Row="10" Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}">
+                <TextBlock VerticalAlignment="Center" Text="Stack:"/>
+            </StackPanel>
+
+            <ComboBox Grid.Row="10" Grid.Column="1" Margin="0,4" 
+                      Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}"
                       ItemsSource="{Binding StackOptions}" 
                       IsEnabled="{Binding IsLoggedIn}"
                       SelectedItem="{Binding SelectedStack}">
             </ComboBox>
+            
         </Grid>
 
         <StackPanel 
             DockPanel.Dock="Bottom"
-            Margin="0,0,12,12"
+            Margin="12"
             Orientation="Horizontal"
             Grid.Row="7"
             Grid.Column="1"

--- a/src/WpfViews/src/DeploymentDialogView.xaml
+++ b/src/WpfViews/src/DeploymentDialogView.xaml
@@ -335,15 +335,16 @@
             HorizontalAlignment="Right">
 
             <Button 
-                Content="{ Binding DeploymentButtonLabel }" 
-                Width="160" 
+                Content="Push App" 
                 HorizontalAlignment="Right"
-                Margin="0,4"
+                Margin="4"
+                Padding="4"
                 Command="{ Binding ElementName=DeploymentDialogViewElement, Path=UploadAppCommand }" 
                 CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"/>
 
             <Button 
-                Margin="8,4,0,4"
+                Margin="4"
+                Padding="4"
                 Click="Close"
                 Content="Cancel"/>
         </StackPanel>

--- a/src/WpfViews/src/DeploymentDialogView.xaml
+++ b/src/WpfViews/src/DeploymentDialogView.xaml
@@ -20,6 +20,7 @@
         <converters:VisibilityConverter x:Key="Visibility" />
         <converters:VisibilityConverter x:Key="InverseVisibility" Reversed="True"/>
         <converters:VisibilityConverter x:Key="ExpansionConverter" ReserveSpace="False" />
+        <converters:ListToStringConverter x:Key="SelectedBuildpacksStringListConverter" EmptyListMessage="&lt;none selected&gt;" />
 
         <Style x:Key="RoundedButtonStyle" TargetType="{x:Type Button}">
             <Setter Property="Template">
@@ -32,6 +33,7 @@
                 </Setter.Value>
             </Setter>
         </Style>
+
     </Window.Resources>
 
     <DockPanel LastChildFill="False">
@@ -40,7 +42,7 @@
             <TextBlock FontSize="24" Text="Push to Tanzu Application Service" Margin="4" Grid.Row="0" Grid.Column="1"/>
         </StackPanel>
 
-        <Grid x:Name="GridBody" Width="414" VerticalAlignment="Top" Margin="8,8,8,0" DockPanel.Dock="Top">
+        <Grid x:Name="MainContent" Width="414" VerticalAlignment="Top" Margin="8,8,8,0" DockPanel.Dock="Top">
             <Grid.RowDefinitions>
                 <!--ROW 0-->
                 <RowDefinition Height="42"></RowDefinition>
@@ -56,14 +58,6 @@
                 <RowDefinition Height="32"></RowDefinition>
                 <!--ROW 6-->
                 <RowDefinition Height="32"></RowDefinition>
-                <!--ROW 7-->
-                <RowDefinition Height="auto"></RowDefinition>
-                <!--ROW 8-->
-                <RowDefinition Height="auto"></RowDefinition>
-                <!--ROW 9-->
-                <RowDefinition Height="auto"></RowDefinition>
-                <!--ROW 10-->
-                <RowDefinition Height="auto"></RowDefinition>
             </Grid.RowDefinitions>
 
             <Grid.ColumnDefinitions>
@@ -71,7 +65,7 @@
                 <ColumnDefinition Width="*"></ColumnDefinition>
             </Grid.ColumnDefinitions>
 
-            <!--ROW 0-->
+            <!--MAIN GRID ROW 0-->
             <StackPanel VerticalAlignment="Center" Grid.Row="0">
                 <TextBlock VerticalAlignment="Center" Text="Deployment Target:" />
             </StackPanel>
@@ -92,11 +86,11 @@
                    Margin="4,0,0,0"
                    Visibility="{Binding IsLoggedIn, Converter={StaticResource Visibility}}"/>
 
-            <!--ROW 1-->
+            <!--MAIN GRID ROW 1-->
             <Separator Grid.Row="1"
                        Visibility="Hidden"/>
 
-            <!--ROW 2-->
+            <!--MAIN GRID ROW 2-->
             <TextBlock Grid.Row="2" Text="App Manifest:" VerticalAlignment="Center"/>
 
             <Grid Grid.Row="2" Grid.Column="1" VerticalAlignment="Center">
@@ -129,7 +123,7 @@
                 </Button>
             </Grid>
 
-            <!--ROW 3-->
+            <!--MAIN GRID ROW 3-->
             <TextBlock Grid.Row="3" Text="App Name:" VerticalAlignment="Center"/>
 
             <TextBox Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="1" 
@@ -140,7 +134,7 @@
                      VerticalAlignment="Center" 
                      VerticalContentAlignment="Center"/>
 
-            <!--ROW 4-->
+            <!--MAIN GRID ROW 4-->
             <StackPanel VerticalAlignment="Center" Grid.Row="4">
                 <TextBlock VerticalAlignment="Center" Text="Target Organization:"/>
             </StackPanel>
@@ -157,7 +151,7 @@
                 </ComboBox.ItemTemplate>
             </ComboBox>
 
-            <!--ROW 5-->
+            <!--MAIN GRID ROW 5-->
             <StackPanel VerticalAlignment="Center" Grid.Row="5">
                 <TextBlock VerticalAlignment="Center" Text="Target Space:"/>
             </StackPanel>
@@ -173,7 +167,7 @@
                 </ComboBox.ItemTemplate>
             </ComboBox>
 
-            <!--ROW 6-->
+            <!--MAIN GRID ROW 6-->
             <Button Command="{Binding ElementName=DeploymentDialogViewElement, Path=ToggleAdvancedOptionsCommand}"
                     Grid.Row="6"
                     Grid.Column="0"
@@ -207,20 +201,40 @@
                            Margin="2"/>
                 </Grid>
             </Button>
+        </Grid>
 
-            <!--ROW 7-->
-            <Separator Grid.Row="7" Grid.ColumnSpan="2" 
-                       Margin="0,12"
-                       Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}"/>
+        <Grid
+            Name="HiddenContent"
+            Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}"
+            Width="414"
+            VerticalAlignment="Top"
+            Margin="8,8,8,0"
+            DockPanel.Dock="Top">
+            
+            <Grid.RowDefinitions>
+                <RowDefinition Height="auto"/>
+                <RowDefinition Height="auto"/>
+                <RowDefinition Height="auto"/>
+                <RowDefinition Height="auto"/>
+                <RowDefinition Height="auto"/>
+            </Grid.RowDefinitions>
+                
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="128"></ColumnDefinition>
+                <ColumnDefinition Width="*"></ColumnDefinition>
+            </Grid.ColumnDefinitions>
 
-            <!--ROW 8-->
-            <TextBlock Grid.Row="8" 
-                       Text="Directory to Push:" 
-                       VerticalAlignment="Center" 
-                       Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}"
-                       ToolTip="Path to app directory or to a zip file of the contents of the app directory"/>
+            <!--HIDDEN GRID ROW 0-->
+            <Separator Grid.Row="0" Grid.ColumnSpan="2" 
+                        Margin="0,12"/>
 
-            <Grid Grid.Row="8" Grid.Column="1" VerticalAlignment="Center" Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}">
+            <!--HIDDEN GRID ROW 1-->
+            <TextBlock Grid.Row="1" 
+                        Text="Directory to Push:" 
+                        VerticalAlignment="Center" 
+                        ToolTip="Path to app directory or to a zip file of the contents of the app directory"/>
+
+            <Grid Grid.Row="1" Grid.Column="1" VerticalAlignment="Center">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="32"></RowDefinition>
                 </Grid.RowDefinitions>
@@ -253,30 +267,64 @@
                 </Button>
             </Grid>
 
-            <!-- ROW 9-->
-            <StackPanel VerticalAlignment="Center" Grid.Row="9" Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}">
-                <TextBlock VerticalAlignment="Center" Text="Buildpack:" />
+            <!--HIDDEN GRID ROW 2-->
+            <StackPanel
+                VerticalAlignment="Center"
+                Grid.Row="2"
+                Grid.Column="0">
+                
+                <TextBlock
+                    VerticalAlignment="Top"
+                    Grid.Row="2"
+                    Grid.Column="0"
+                    Text="Buildpack:"/>
+                
+                <TextBlock
+                    Text="(If multiple buildpacks selected, only the *last* buildpack will be used)"
+                    Visibility="{Binding IsLoggedIn, Converter={StaticResource ExpansionConverter}}"
+                    Foreground="Gray"
+                    Margin="4"
+                    TextWrapping="Wrap"
+                    FontSize="10"
+                    FontStyle="Italic"
+                    />
             </StackPanel>
 
-            <ComboBox Grid.Row="9" Grid.Column="1" Margin="0,4" 
-                      Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}"
-                      ItemsSource="{Binding BuildpackOptions}" 
-                      IsEnabled="{Binding IsLoggedIn}"
-                      SelectedItem="{Binding SelectedBuildpack}">
-            </ComboBox>
-            
-            <!-- ROW 10-->
-            <StackPanel VerticalAlignment="Center" Grid.Row="10" Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}">
+            <StackPanel
+                Grid.Row="2"
+                Grid.Column="1">
+
+                <Label
+                    Content="{Binding SelectedBuildpacks, Converter={StaticResource SelectedBuildpacksStringListConverter}}"
+                    ToolTip="{Binding SelectedBuildpacks, Converter={StaticResource SelectedBuildpacksStringListConverter}}"
+                    IsEnabled="{Binding IsLoggedIn}"/>
+
+                <ListBox
+                    Grid.Row="2"
+                    Grid.Column="1"
+                    Margin="0,4"
+                    MaxHeight="128"
+                    SelectionMode="Multiple"
+                    Visibility="{Binding IsLoggedIn, Converter={StaticResource ExpansionConverter}}"
+                    ItemsSource="{Binding BuildpackOptions}"
+                    IsEnabled="{Binding IsLoggedIn}"
+                    SelectionChanged="ListBox_SelectionChanged"/>
+            </StackPanel>
+
+
+            <!--HIDDEN GRID ROW 3-->
+            <StackPanel VerticalAlignment="Center" Grid.Row="3">
                 <TextBlock VerticalAlignment="Center" Text="Stack:"/>
             </StackPanel>
 
-            <ComboBox Grid.Row="10" Grid.Column="1" Margin="0,4" 
-                      Visibility="{Binding Expanded, Converter={StaticResource ExpansionConverter}}"
-                      ItemsSource="{Binding StackOptions}" 
-                      IsEnabled="{Binding IsLoggedIn}"
-                      SelectedItem="{Binding SelectedStack}">
+            <ComboBox
+                Grid.Row="3"
+                Grid.Column="1"
+                Margin="0,4"
+                ItemsSource="{Binding StackOptions}"
+                IsEnabled="{Binding IsLoggedIn}"
+                SelectedItem="{Binding SelectedStack}">
             </ComboBox>
-            
         </Grid>
 
         <StackPanel 

--- a/src/WpfViews/src/DeploymentDialogView.xaml
+++ b/src/WpfViews/src/DeploymentDialogView.xaml
@@ -210,7 +210,7 @@
             VerticalAlignment="Top"
             Margin="8,8,8,0"
             DockPanel.Dock="Top">
-            
+
             <Grid.RowDefinitions>
                 <RowDefinition Height="auto"/>
                 <RowDefinition Height="auto"/>
@@ -218,7 +218,7 @@
                 <RowDefinition Height="auto"/>
                 <RowDefinition Height="auto"/>
             </Grid.RowDefinitions>
-                
+
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="128"></ColumnDefinition>
                 <ColumnDefinition Width="*"></ColumnDefinition>
@@ -268,27 +268,12 @@
             </Grid>
 
             <!--HIDDEN GRID ROW 2-->
-            <StackPanel
-                VerticalAlignment="Center"
+            <TextBlock
+                VerticalAlignment="Top"
+                Margin="0,4"
                 Grid.Row="2"
-                Grid.Column="0">
-                
-                <TextBlock
-                    VerticalAlignment="Top"
-                    Grid.Row="2"
-                    Grid.Column="0"
-                    Text="Buildpack:"/>
-                
-                <TextBlock
-                    Text="(If multiple buildpacks selected, only the *last* buildpack will be used)"
-                    Visibility="{Binding IsLoggedIn, Converter={StaticResource ExpansionConverter}}"
-                    Foreground="Gray"
-                    Margin="4"
-                    TextWrapping="Wrap"
-                    FontSize="10"
-                    FontStyle="Italic"
-                    />
-            </StackPanel>
+                Grid.Column="0"
+                Text="Buildpack:"/>
 
             <StackPanel
                 Grid.Row="2"
@@ -314,14 +299,14 @@
                         </Style>
                     </ListView.ItemContainerStyle>
                     <ListView.ItemTemplate>
-                    <DataTemplate>
-                       <CheckBox 
+                        <DataTemplate>
+                            <CheckBox 
                            Content="{Binding}" 
                            IsChecked="{Binding IsChecked}"
                            Checked="CheckBox_Checked"
                            Unchecked="CheckBox_Unchecked"/>
-                    </DataTemplate>
-                  </ListView.ItemTemplate>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
                 </ListView>
             </StackPanel>
 

--- a/src/WpfViews/src/DeploymentDialogView.xaml.cs
+++ b/src/WpfViews/src/DeploymentDialogView.xaml.cs
@@ -32,7 +32,7 @@ namespace Tanzu.Toolkit.WpfViews
             _viewModel = viewModel;
             UploadAppCommand = new DelegatingCommand(viewModel.DeployApp, viewModel.CanDeployApp);
             OpenLoginDialogCommand = new DelegatingCommand(viewModel.OpenLoginView, viewModel.CanOpenLoginView);
-            ToggleAdvancedOptionsCommand = new DelegatingCommand(ToggleAdvancedOptions, viewModel.CanToggleAdvancedOptions);
+            ToggleAdvancedOptionsCommand = new DelegatingCommand(viewModel.ToggleAdvancedOptions, viewModel.CanToggleAdvancedOptions);
 
             themeService.SetTheme(this);
             DataContext = viewModel;
@@ -72,22 +72,6 @@ namespace Tanzu.Toolkit.WpfViews
             if (openFolderDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
                 _viewModel.DeploymentDirectoryPath = openFolderDialog.SelectedPath;
-            }
-        }
-
-        private void ToggleAdvancedOptions(object arg)
-        {
-            _viewModel.ToggleAdvancedOptions(arg);
-            
-            if (_viewModel.Expanded)
-            {
-                Height = (double)Resources["expandedWindowHeight"];
-                GridBody.Height = (double)Resources["expandedGridBodyHeight"]; ;
-            }
-            else
-            {
-                Height = (double)Resources["collapsedWindowHeight"];
-                GridBody.Height = (double)Resources["collapsedGridBodyHeight"]; ;
             }
         }
 

--- a/src/WpfViews/src/DeploymentDialogView.xaml.cs
+++ b/src/WpfViews/src/DeploymentDialogView.xaml.cs
@@ -17,6 +17,7 @@ namespace Tanzu.Toolkit.WpfViews
         public ICommand UploadAppCommand { get; }
         public ICommand OpenLoginDialogCommand { get; }
         public ICommand ToggleAdvancedOptionsCommand { get; }
+        public ICommand ClearBuildpackSelectionCommand { get; }
 
         public Brush HyperlinkBrush { get { return (Brush)GetValue(HyperlinkBrushProperty); } set { SetValue(HyperlinkBrushProperty, value); } }
 
@@ -33,6 +34,7 @@ namespace Tanzu.Toolkit.WpfViews
             UploadAppCommand = new DelegatingCommand(viewModel.DeployApp, viewModel.CanDeployApp);
             OpenLoginDialogCommand = new DelegatingCommand(viewModel.OpenLoginView, viewModel.CanOpenLoginView);
             ToggleAdvancedOptionsCommand = new DelegatingCommand(viewModel.ToggleAdvancedOptions, viewModel.CanToggleAdvancedOptions);
+            ClearBuildpackSelectionCommand = new DelegatingCommand(viewModel.ClearSelectedBuildpacks, (object arg) => { return true; });
 
             themeService.SetTheme(this);
             DataContext = viewModel;

--- a/src/WpfViews/src/DeploymentDialogView.xaml.cs
+++ b/src/WpfViews/src/DeploymentDialogView.xaml.cs
@@ -40,7 +40,7 @@ namespace Tanzu.Toolkit.WpfViews
             
             MouseDown += Window_MouseDown;
         }
-
+       
         private void CfOrgOptions_ComboBox_DropDownClosed(object sender, System.EventArgs e)
         {
             _viewModel.UpdateCfSpaceOptions();
@@ -89,16 +89,19 @@ namespace Tanzu.Toolkit.WpfViews
 
         }
 
-        private void ListBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        private void CheckBox_Checked(object sender, RoutedEventArgs e)
         {
-            foreach (string item in e.RemovedItems)
+            if (e.Source is System.Windows.Controls.CheckBox cb)
             {
-                _viewModel.RemoveFromSelectedBuildpacks(item);
+                _viewModel.AddToSelectedBuildpacks(cb.Content);
             }
+        }
 
-            foreach (string item in e.AddedItems)
+        private void CheckBox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (e.Source is System.Windows.Controls.CheckBox cb)
             {
-                _viewModel.AddToSelectedBuildpacks(item);
+                _viewModel.RemoveFromSelectedBuildpacks(cb.Content);
             }
         }
     }

--- a/src/WpfViews/src/DeploymentDialogView.xaml.cs
+++ b/src/WpfViews/src/DeploymentDialogView.xaml.cs
@@ -88,5 +88,18 @@ namespace Tanzu.Toolkit.WpfViews
             }
 
         }
+
+        private void ListBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            foreach (string item in e.RemovedItems)
+            {
+                _viewModel.RemoveFromSelectedBuildpacks(item);
+            }
+
+            foreach (string item in e.AddedItems)
+            {
+                _viewModel.AddToSelectedBuildpacks(item);
+            }
+        }
     }
 }

--- a/src/WpfViews/src/Tanzu.Toolkit.WpfViews.csproj
+++ b/src/WpfViews/src/Tanzu.Toolkit.WpfViews.csproj
@@ -77,6 +77,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Commands\AsyncDelegatingCommand.cs" />
+    <Compile Include="Converters\ListToStringConverter.cs" />
     <Compile Include="ICloudExplorerView.cs" />
     <Compile Include="ILoginView.cs" />
     <Compile Include="IDeploymentDialogView.cs" />

--- a/src/WpfViews/test/ViewTestSupport.cs
+++ b/src/WpfViews/test/ViewTestSupport.cs
@@ -6,6 +6,7 @@ using Tanzu.Toolkit.Services;
 using Tanzu.Toolkit.Services.CloudFoundry;
 using Tanzu.Toolkit.Services.Dialog;
 using Tanzu.Toolkit.Services.ErrorDialog;
+using Tanzu.Toolkit.Services.File;
 using Tanzu.Toolkit.Services.Logging;
 using Tanzu.Toolkit.Services.Threading;
 using Tanzu.Toolkit.Services.ViewLocator;
@@ -30,6 +31,7 @@ namespace Tanzu.Toolkit.WpfViews.Tests
         protected Mock<IThreadingService> mockThreadingService;
         protected Mock<IThemeService> mockThemeService;
         protected Mock<IViewService> mockViewService;
+        protected Mock<IFileService> mockFileService;
 
         // ViewModels
         protected Mock<ITasExplorerViewModel> mockTasExplorerViewModel;
@@ -47,6 +49,7 @@ namespace Tanzu.Toolkit.WpfViews.Tests
             mockThemeService = new Mock<IThemeService>();
             mockViewService = new Mock<IViewService>();
             mockTasExplorerViewModel = new Mock<ITasExplorerViewModel>();
+            mockFileService = new Mock<IFileService>();
 
             mockLogger = new Mock<ILogger>();
             mockLoggingService.SetupGet(m => m.Logger).Returns(mockLogger.Object);
@@ -61,6 +64,7 @@ namespace Tanzu.Toolkit.WpfViews.Tests
             services.AddSingleton(mockThemeService.Object);
             services.AddSingleton(mockViewService.Object);
             services.AddSingleton(mockTasExplorerViewModel.Object);
+            services.AddSingleton(mockFileService.Object);
 
             this.services = services.BuildServiceProvider();
         }


### PR DESCRIPTION
- Add new method for requesting list of buildpacks from CF API
- Model buildpacks response
- Model CF App Manifest
- Refactor CfCli.PushAppAsync to ONLY accept a path to a manifest file for app deployment (remove ability to amend a `cf push` via extra command line arguments like -b for buildpack specification; all push config must be contained within some manifest file)
- Refactor CloudFoundryService.DeployAppASync to ONLY pass an AppManifest for app deployment (remove individual arguments for values like buildpacks/stack etc.)
- Rename FileLocatorService => FileService
- Delegate file system operations to FileService (added layer of abstraction allows for easy mocks in unit tests)
- Add NuGet package "YamlDotNet" for (de)serializing yaml files
- Add new method to CloudFoundryService to parse app manifest from yaml file
- Add new method to CloudFoundryService to write a (temporary) manifest yaml file from an AppManifest object
- Add new buildpack selection field to DeploymentDialog view (list view of checkboxes for buildpack names received from the CF API)
- Add new methods for Adding, Removing & Clearing buildpack selection in Deployment Dialog
- Add new class BuildpackListItem to facilitate fine control over buildpack selection in DeploymentDialogView (BuildpackListItem contains property "IsSelected" & implements INotifyPropertyChanged)
- Record app deployment config values in an AppManifest property (called "ManifestModel") on DeploymentDialogViewModel
- If manifest is provided (or default manifest is found at app root directory when push is initiated), pull the values from that yaml file into DeploymentDialogViewModel.ManifestModel
- Whenever AppName, DeploymentDirectoryPath, SelectedBuildpacks, or SelectedStack values change in the DeploymentDialog, update DeploymentDialogViewModel.ManifestModel with the new values
- Pass DeploymentDialogViewModel.ManifestModel onto CloudFoundryService from DeploymentDialogViewModel to be re-serialized into yaml & used for `cf push`