### PR TITLE
Disable buildpacks based on stack selection [#180]

### DIFF
--- a/src/Models/src/AppManifest.cs
+++ b/src/Models/src/AppManifest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Tanzu.Toolkit.Models
 {
@@ -6,9 +7,25 @@ namespace Tanzu.Toolkit.Models
     {
         public int Version { get; set; }
         public List<AppConfig> Applications { get; set; }
+
+        public AppManifest DeepClone()
+        {
+            var appsList = new List<AppConfig>();
+
+            foreach (AppConfig app in Applications)
+            {
+                appsList.Add((AppConfig)app.Clone());
+            }
+
+            return new AppManifest
+            {
+                Version = Version,
+                Applications = appsList,
+            };
+        }
     }
 
-    public class AppConfig
+    public class AppConfig : ICloneable
     {
         public List<string> Buildpacks { get; set; }
         public string Command { get; set; }
@@ -30,6 +47,149 @@ namespace Tanzu.Toolkit.Models
         public List<string> Services { get; set; }
         public List<SidecarConfig> Sidecars { get; set; }
         public string Stack { get; set; }
+
+        public object Clone()
+        {
+            // shallow copy first to replicate all value types
+            AppConfig newApp = (AppConfig)MemberwiseClone();
+
+            // complete deep copy by replicating all reference types
+
+            if (Buildpacks != null)
+            {
+                var clonedBps = new List<string>();
+
+                foreach (string bpName in Buildpacks)
+                {
+                    clonedBps.Add(bpName);
+                }
+
+                newApp.Buildpacks = clonedBps;
+            }
+
+            if (Docker != null)
+            {
+                var clonedDockerConfig = new DockerConfig
+                {
+                    Image = Docker.Image,
+                    Username = Docker.Username,
+                };
+
+                newApp.Docker = clonedDockerConfig;
+            }
+
+            if (Env != null)
+            {
+                var clonedEnv = new Dictionary<string, string>();
+
+                foreach (string key in Env.Keys)
+                {
+                    clonedEnv.Add(key, Env[key]);
+                }
+
+                newApp.Env = clonedEnv;
+            }
+
+
+            if (Metadata != null)
+            {
+                if (Metadata.Annotations != null)
+                {
+                    var clonedAnnotations = new Dictionary<string, string>();
+
+                    foreach (string key in Metadata.Annotations.Keys)
+                    {
+                        clonedAnnotations.Add(key, Metadata.Annotations[key]);
+                    }
+
+                    newApp.Metadata.Annotations = clonedAnnotations;
+                }
+
+                if (Metadata.Labels != null)
+                {
+                    var clonedAnnotations = new Dictionary<string, string>();
+
+                    foreach (string key in Metadata.Labels.Keys)
+                    {
+                        clonedAnnotations.Add(key, Metadata.Labels[key]);
+                    }
+
+                    newApp.Metadata.Labels = clonedAnnotations;
+                }
+            }
+
+            if (Processes != null)
+            {
+                var newProcessList = new List<ProcessConfig>();
+
+                foreach (ProcessConfig process in Processes)
+                {
+                    newProcessList.Add(new ProcessConfig
+                    {
+                        Command = process.Command,
+                        DiskQuota = process.DiskQuota,
+                        HealthCheckHttpEndpoint = process.HealthCheckHttpEndpoint,
+                        HealthCheckInvocationTimeout = process.HealthCheckInvocationTimeout,
+                        HealthCheckType = process.HealthCheckType,
+                        Instances = process.Instances,
+                        Memory = process.Memory,
+                        Timeout = process.Timeout,
+                        Type = process.Type,
+                    });
+                }
+
+                newApp.Processes = newProcessList;
+            }
+
+            if (Routes != null)
+            {
+                var newRoutesList = new List<RouteConfig>();
+
+                foreach (RouteConfig route in Routes)
+                {
+                    newRoutesList.Add(new RouteConfig
+                    {
+                        Protocol = route.Protocol,
+                        Route = route.Route,
+                    });
+                }
+
+                newApp.Routes = newRoutesList;
+            }
+
+            if (Sidecars != null)
+            {
+                var newSidecarList = new List<SidecarConfig>();
+
+                foreach (SidecarConfig sidecar in Sidecars)
+                {
+                    var newSidecar = new SidecarConfig
+                    {
+                        Name = sidecar.Name,
+                        Command = sidecar.Command,
+                        Memory = sidecar.Memory,
+                    };
+
+                    if (sidecar.ProcessTypes != null)
+                    {
+                        var processTypeList = new List<string>();
+
+                        foreach (string procType in sidecar.ProcessTypes)
+                        {
+                            processTypeList.Add(procType);
+                        }
+
+                        newSidecar.ProcessTypes = processTypeList;
+                    }
+
+                    newSidecarList.Add(newSidecar);
+                }
+
+                newApp.Sidecars = newSidecarList;
+            }
+
+            return newApp;
+        }
     }
 
     public class DockerConfig
@@ -61,13 +221,6 @@ namespace Tanzu.Toolkit.Models
     {
         public string Route { get; set; }
         public string Protocol { get; set; }
-    }
-
-    public class ServiceConfig
-    {
-        public string Name { get; set; }
-        public string BindingName { get; set; }
-        public Dictionary<object, object> Parameters { get; set; }
     }
 
     public class SidecarConfig

--- a/src/Models/src/CfBuildpack.cs
+++ b/src/Models/src/CfBuildpack.cs
@@ -1,0 +1,8 @@
+﻿namespace Tanzu.Toolkit.Models
+{
+    public class CfBuildpack
+    {
+        public string Name { get; set; }
+        public string Stack { get; set; }
+    }
+}

--- a/src/Services/src/CloudFoundry/ICloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/ICloudFoundryService.cs
@@ -16,7 +16,7 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
         Task<DetailedResult> StartAppAsync(CloudFoundryApp app, bool skipSsl = true, int retryAmount = 1);
         Task<DetailedResult> DeleteAppAsync(CloudFoundryApp app, bool skipSsl = true, bool removeRoutes = true, int retryAmount = 1);
         Task<DetailedResult<string>> GetRecentLogs(CloudFoundryApp app);
-        Task<DetailedResult<List<string>>> GetUniqueBuildpackNamesAsync(string apiAddress, int retryAmount = 1);
+        Task<DetailedResult<List<CfBuildpack>>> GetBuildpacksAsync(string apiAddress, int retryAmount = 1);
         DetailedResult CreateManifestFile(string location, AppManifest manifest);
         Task<DetailedResult> DeployAppAsync(AppManifest appManifest, CloudFoundryInstance targetCf, CloudFoundryOrganization targetOrg, CloudFoundrySpace targetSpace, StdOutDelegate stdOutCallback, StdErrDelegate stdErrCallback);
         Task<DetailedResult<List<string>>> GetStackNamesAsync(CloudFoundryInstance cf, int retryAmount = 1);

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -1220,6 +1220,129 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         }
 
         [TestMethod]
+        [TestCategory("SelectedStack")]
+        [TestCategory("SelectedBuildpacks")]
+        public void SelectedStackSetter_EvaluatesStackCompatibilityWithBuildpackOptions_AndDeselectsIncompatibleBuildpacks()
+        {
+            var newStackVal = "windows";
+            var initialStackInManifestModel = _sut.ManifestModel.Applications[0].Stack;
+
+            /** Matrix: all possible buildpack selection / stack compatibility changes when changing selectedStack value
+             * 	oldComp	oldSelected	newComp	newSelected
+             * 	0	    0		    0	    0	    incompatibleDeselectedBpToStayIncompatibleAndDeselected
+             * 	0	    0		    0	    1	    N/A - no spontaneous selection
+             * 	0	    0		    1	    0	    incompatibleDeselectedBpToBecomeCompatibleAndStayDeselected
+             * 	0	    0		    1	    1	    N/A - no spontaneous selection
+             * 	0	    1		    0	    0	    N/A - can't start compatible and selected
+             * 	0	    1		    0	    1	    N/A - can't start compatible and selected
+             * 	0	    1		    1	    0	    N/A - can't start compatible and selected
+             * 	0	    1		    1	    1	    N/A - can't start compatible and selected
+             * 	1	    0		    0	    0	    compatibleDeselectedBpToBecomeIncompatibleAndStayDeselected
+             * 	1	    0		    0	    1	    N/A - no spontaneous selection
+             * 	1	    0		    1	    0	    compatibleDeselectedBpToStayCompatibleAndDeselected
+             * 	1	    0		    1	    1	    N/A - no spontaneous selection
+             * 	1	    1		    0	    0	    compatibleSelectedBpToBecomeIncompatibleAndDeselected
+             * 	1	    1		    0	    1	    N/A - can't be selected if not compatible
+             * 	1	    1		    1	    0   	N/A - should say selected if compatible with both new & old stacks
+             * 	1	    1		    1	    1	    compatibleSelectedBpToStayCompatibleAndSelected 
+             */
+
+            var incompatibleDeselectedBpToStayIncompatibleAndDeselected = new FakeBuildpackListItem(
+                "incompatibleDeselectedBpToStayIncompatibleAndDeselected",
+                selected: false,
+                compatibleWithCurrentStack: false,
+                stacks: new List<string> { "unusedStack" });
+
+            var incompatibleDeselectedBpToBecomeCompatibleAndStayDeselected = new FakeBuildpackListItem(
+                "incompatibleDeselectedBpToBecomeCompatibleAndStayDeselected",
+                selected: false,
+                compatibleWithCurrentStack: false,
+                stacks: new List<string> { newStackVal });
+
+            var compatibleDeselectedBpToBecomeIncompatibleAndStayDeselected = new FakeBuildpackListItem(
+                "compatibleDeselectedBpToBecomeIncompatibleAndStayDeselected",
+                selected: false,
+                compatibleWithCurrentStack: true,
+                stacks: new List<string> { initialStackInManifestModel });
+
+            var compatibleDeselectedBpToStayCompatibleAndDeselected = new FakeBuildpackListItem(
+                "compatibleDeselectedBpToStayCompatibleAndDeselected",
+                selected: false,
+                compatibleWithCurrentStack: true,
+                stacks: new List<string> { initialStackInManifestModel, newStackVal });
+
+            var compatibleSelectedBpToBecomeIncompatibleAndDeselected = new FakeBuildpackListItem(
+                "compatibleSelectedBpToBecomeIncompatibleAndDeselected",
+                selected: true,
+                compatibleWithCurrentStack: true,
+                stacks: new List<string> { initialStackInManifestModel });
+
+            var compatibleSelectedBpToStayCompatibleAndSelected = new FakeBuildpackListItem(
+                "compatibleSelectedBpToStayCompatibleAndSelected",
+                selected: true,
+                compatibleWithCurrentStack: true,
+                stacks: new List<string> { initialStackInManifestModel, newStackVal });
+
+            _sut.BuildpackOptions = new List<BuildpackListItem>
+            {
+                incompatibleDeselectedBpToStayIncompatibleAndDeselected,
+                incompatibleDeselectedBpToBecomeCompatibleAndStayDeselected,
+                compatibleDeselectedBpToBecomeIncompatibleAndStayDeselected,
+                compatibleDeselectedBpToStayCompatibleAndDeselected,
+                compatibleSelectedBpToBecomeIncompatibleAndDeselected,
+                compatibleSelectedBpToStayCompatibleAndSelected,
+            };
+
+            _sut.SelectedBuildpacks = new ObservableCollection<string>
+            {
+                compatibleSelectedBpToBecomeIncompatibleAndDeselected.Name,
+                compatibleSelectedBpToStayCompatibleAndSelected.Name,
+            };
+
+            _receivedEvents.Clear();
+
+            Assert.AreNotEqual(newStackVal, initialStackInManifestModel);
+
+            Assert.IsFalse(incompatibleDeselectedBpToStayIncompatibleAndDeselected.IsSelected);
+            Assert.IsFalse(incompatibleDeselectedBpToStayIncompatibleAndDeselected.CompatibleWithStack);
+            Assert.IsFalse(incompatibleDeselectedBpToBecomeCompatibleAndStayDeselected.IsSelected);
+            Assert.IsFalse(incompatibleDeselectedBpToBecomeCompatibleAndStayDeselected.CompatibleWithStack);
+            Assert.IsFalse(compatibleDeselectedBpToBecomeIncompatibleAndStayDeselected.IsSelected);
+            Assert.IsTrue(compatibleDeselectedBpToBecomeIncompatibleAndStayDeselected.CompatibleWithStack);
+            Assert.IsFalse(compatibleDeselectedBpToStayCompatibleAndDeselected.IsSelected);
+            Assert.IsTrue(compatibleDeselectedBpToStayCompatibleAndDeselected.CompatibleWithStack);
+            Assert.IsTrue(compatibleSelectedBpToBecomeIncompatibleAndDeselected.IsSelected);
+            Assert.IsTrue(compatibleSelectedBpToBecomeIncompatibleAndDeselected.CompatibleWithStack);
+            Assert.IsTrue(compatibleSelectedBpToStayCompatibleAndSelected.IsSelected);
+            Assert.IsTrue(compatibleSelectedBpToStayCompatibleAndSelected.CompatibleWithStack);
+
+            Assert.AreEqual(0, _receivedEvents.Count);
+
+            _sut.SelectedStack = newStackVal;
+
+            Assert.AreEqual(newStackVal, _sut.SelectedStack);
+            Assert.AreEqual(2, _receivedEvents.Count);
+            CollectionAssert.Contains(_receivedEvents, "SelectedStack");
+            CollectionAssert.Contains(_receivedEvents, "SelectedBuildpacks");
+
+            Assert.IsFalse(incompatibleDeselectedBpToStayIncompatibleAndDeselected.IsSelected);
+            Assert.IsFalse(incompatibleDeselectedBpToStayIncompatibleAndDeselected.CompatibleWithStack);
+            Assert.IsFalse(incompatibleDeselectedBpToBecomeCompatibleAndStayDeselected.IsSelected);
+            Assert.IsTrue(incompatibleDeselectedBpToBecomeCompatibleAndStayDeselected.CompatibleWithStack);
+            Assert.IsFalse(compatibleDeselectedBpToBecomeIncompatibleAndStayDeselected.IsSelected);
+            Assert.IsFalse(compatibleDeselectedBpToBecomeIncompatibleAndStayDeselected.CompatibleWithStack);
+            Assert.IsFalse(compatibleDeselectedBpToStayCompatibleAndDeselected.IsSelected);
+            Assert.IsTrue(compatibleDeselectedBpToStayCompatibleAndDeselected.CompatibleWithStack);
+            Assert.IsFalse(compatibleSelectedBpToBecomeIncompatibleAndDeselected.IsSelected);
+            Assert.IsFalse(compatibleSelectedBpToBecomeIncompatibleAndDeselected.CompatibleWithStack);
+            Assert.IsTrue(compatibleSelectedBpToStayCompatibleAndSelected.IsSelected);
+            Assert.IsTrue(compatibleSelectedBpToStayCompatibleAndSelected.CompatibleWithStack);
+
+            Assert.AreEqual(1, _sut.SelectedBuildpacks.Count);
+            CollectionAssert.Contains(_sut.SelectedBuildpacks, compatibleSelectedBpToStayCompatibleAndSelected.Name);
+        }
+
+        [TestMethod]
         [TestCategory("DeploymentDirectoryPath")]
         [TestCategory("DirectoryPathLabel")]
         [TestCategory("ManifestModel")]
@@ -1317,29 +1440,78 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         public async Task UpdateBuildpackOptions_SetsBuildpackOptionsToQueryContent_WhenQuerySucceeds()
         {
             var fakeCf = new FakeCfInstanceViewModel(FakeCfInstance, Services);
-            var fakeBuildpacksContent = new List<string>
+            var fakeBuildpacksContent = new List<CfBuildpack>
             {
-                "my_cool_bp",
-                "ruby_buildpack",
-                "topaz_buildpack",
-                "emerald_buildpack",
+                new CfBuildpack
+                {
+                    Name = "bp1",
+                    Stack = "stack1",
+                },
+                new CfBuildpack
+                {
+                    Name = "bp1",
+                    Stack = "stack2",
+                },
+                new CfBuildpack
+                {
+                    Name = "bp1",
+                    Stack = "stack3",
+                },
+                new CfBuildpack
+                {
+                    Name = "bp2",
+                    Stack = "stack1",
+                },
+                new CfBuildpack
+                {
+                    Name = "bp3",
+                    Stack = "stack2",
+                },
             };
-            var fakeBuildpacksResponse = new DetailedResult<List<string>>(succeeded: true, content: fakeBuildpacksContent);
+            var numUniqueBpNamesInFakeResponse = fakeBuildpacksContent.GroupBy(bp => bp.Name).Select(g => g.FirstOrDefault()).ToList().Count;
+
+            var fakeBuildpacksResponse = new DetailedResult<List<CfBuildpack>>
+            {
+                Succeeded = true,
+                Content = fakeBuildpacksContent
+            };
+
+            // simulate builpack specification in a pre-loaded manifest; expect corresponding bp list item to be marked as selected
+            _sut.ManifestModel.Applications[0].Buildpacks = new List<string> { "bp2" };
+
+            // simulate existing stack selection; expect corresponding bp list items to be appopriately marked as (in)compatible
+            _sut.SelectedStack = "stack1";
 
             MockTasExplorerViewModel.SetupGet(m => m.TasConnection).Returns(fakeCf);
 
-            MockCloudFoundryService.Setup(m => m.GetUniqueBuildpackNamesAsync(fakeCf.CloudFoundryInstance.ApiAddress, 1)).ReturnsAsync(fakeBuildpacksResponse);
+            MockCloudFoundryService.Setup(m => m.GetBuildpacksAsync(fakeCf.CloudFoundryInstance.ApiAddress, 1)).ReturnsAsync(fakeBuildpacksResponse);
 
-            Assert.AreNotEqual(fakeBuildpacksContent, _sut.BuildpackOptions);
+            CollectionAssert.AreNotEquivalent(fakeBuildpacksContent, _sut.BuildpackOptions);
             CollectionAssert.DoesNotContain(_receivedEvents, "BuildpackOptions");
 
             await _sut.UpdateBuildpackOptions();
 
-            Assert.AreEqual(fakeBuildpacksContent.Count, _sut.BuildpackOptions.Count);
-            foreach (BuildpackListItem bp in _sut.BuildpackOptions)
-            {
-                Assert.IsTrue(fakeBuildpacksContent.Contains(bp.Name));
-            }
+            Assert.AreEqual(numUniqueBpNamesInFakeResponse, _sut.BuildpackOptions.Count);
+
+            Assert.IsTrue(_sut.BuildpackOptions.Exists(bp => bp.Name == "bp1"
+                                                             && bp.ValidStacks.Count == 3
+                                                             && bp.ValidStacks.Contains("stack1")
+                                                             && bp.ValidStacks.Contains("stack2")
+                                                             && bp.ValidStacks.Contains("stack3")
+                                                             && bp.IsSelected == false
+                                                             && bp.CompatibleWithStack == true));
+
+            Assert.IsTrue(_sut.BuildpackOptions.Exists(bp => bp.Name == "bp2"
+                                                             && bp.ValidStacks.Count == 1
+                                                             && bp.ValidStacks.Contains("stack1")
+                                                             && bp.IsSelected == true
+                                                             && bp.CompatibleWithStack == true));
+
+            Assert.IsTrue(_sut.BuildpackOptions.Exists(bp => bp.Name == "bp3"
+                                                             && bp.ValidStacks.Count == 1
+                                                             && bp.ValidStacks.Contains("stack2")
+                                                             && bp.IsSelected == false
+                                                             && bp.CompatibleWithStack == false));
 
             CollectionAssert.Contains(_receivedEvents, "BuildpackOptions");
         }
@@ -1350,11 +1522,11 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         {
             var fakeCf = new FakeCfInstanceViewModel(FakeCfInstance, Services);
             const string fakeFailureReason = "junk";
-            var fakeBuildpacksResponse = new DetailedResult<List<string>>(succeeded: false, content: null, explanation: fakeFailureReason, cmdDetails: null);
+            var fakeBuildpacksResponse = new DetailedResult<List<CfBuildpack>>(succeeded: false, content: null, explanation: fakeFailureReason, cmdDetails: null);
 
             MockTasExplorerViewModel.SetupGet(m => m.TasConnection).Returns(fakeCf);
 
-            MockCloudFoundryService.Setup(m => m.GetUniqueBuildpackNamesAsync(fakeCf.CloudFoundryInstance.ApiAddress, 1)).ReturnsAsync(fakeBuildpacksResponse);
+            MockCloudFoundryService.Setup(m => m.GetBuildpacksAsync(fakeCf.CloudFoundryInstance.ApiAddress, 1)).ReturnsAsync(fakeBuildpacksResponse);
 
             CollectionAssert.DoesNotContain(_receivedEvents, "BuildpackOptions");
 
@@ -1650,6 +1822,26 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         public void Show()
         {
             ShowMethodWasCalled = true;
+        }
+    }
+
+    public class FakeBuildpackListItem : BuildpackListItem
+    {
+        public FakeBuildpackListItem(string name, bool selected, bool compatibleWithCurrentStack, List<string> stacks)
+        {
+            Name = name;
+            IsSelected = selected;
+            ValidStacks = stacks;
+            if (compatibleWithCurrentStack)
+            {
+                // set CompatibleWithStack to true
+                EvalutateStackCompatibility(null);
+            }
+            else
+            {
+                // set CompatibleWithStack to false
+                EvalutateStackCompatibility("some junk that should purposefully not appear in list of stacks");
+            }
         }
     }
 }

--- a/src/WpfViews/src/DeploymentDialogView.xaml
+++ b/src/WpfViews/src/DeploymentDialogView.xaml
@@ -387,6 +387,7 @@
                                 <CheckBox
                                 Content="{Binding Name}"
                                 IsChecked="{Binding IsSelected}"
+                                IsEnabled="{Binding CompatibleWithStack}"
                                 Checked="CheckBox_Checked"
                                 Unchecked="CheckBox_Unchecked"/>
                             </DataTemplate>


### PR DESCRIPTION
- Change CfService.GetUniqueBuildpackNamesAsync => GetBuildpacksAsync
- Dedup buildpack names in DeploymentDialog (no longer in CfService)
- Add "CompatibleWithStack" prop to each builpackListItem
- Bind Wpf "IsEnabled" to buildpackListItem.CompatibleWithStack
- Add "ValidStacks" list prop to each builpackListItem
- Add EvalutateStackCompatibility method to BuildpackListItem; compare
  given stack arg to list of "ValidStacks"
- EvalutateStackCompatibility when setting buildpacks from manifest
- EvalutateStackCompatibility when changing SelectedStack value
- Add DeepClone method to AppManifest model to facilitate instance
  duplication (dedicate a *single* AppManifest instance to
  DeploymentDialogViewModel.ManifestModel to avoid side effects when
  updating view model props with values from supplied manifest files)
- Remove unused ServiceConfig from AppManifest model (only supporting
  strings for service specifications in manifest files)