### PR TITLE
Bump cf cli v7.2 -> v7.3

### DIFF
--- a/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
+++ b/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
@@ -120,11 +120,11 @@
     </VSCTCompile>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Resources\tanzu_deploy_16x.png" />
     <Content Include="Resources\cf7.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Resources\tanzu_deploy_16x.png" />
     <Content Include="Resources\DeployApp.png" />
     <Content Include="Resources\tanzu16.png" />
     <Content Include="Resources\cf6.exe" CopyToOutputDirectory="PreserveNewest">


### PR DESCRIPTION
This fixes a bug that falsely reported a nonexistent hwc_buildpack when pushing apps to windows