### PR TITLE
Persist TAS connection between sessions of Visual Studio

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ variables:
   - name: minor
     value: 0
   - name: patch
-    value: 3
+    value: 4 
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
     value: true
   - name: DOTNET_CLI_TELEMETRY_OPTOUT

--- a/src/Models/src/CloudFoundryInstance.cs
+++ b/src/Models/src/CloudFoundryInstance.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Tanzu.Toolkit.Models
+﻿namespace Tanzu.Toolkit.Models
 {
     public class CloudFoundryInstance
     {
@@ -8,11 +6,9 @@ namespace Tanzu.Toolkit.Models
         {
             InstanceName = name;
             ApiAddress = apiAddress;
-            InstanceId = Guid.NewGuid().ToString("D"); // 'D' format includes hyphens
         }
 
         public string InstanceName { get; set; }
-        public string InstanceId { get; set; }
         public string ApiAddress { get; set; }
     }
 }

--- a/src/Services/src/DataPersistence/IDataPersistenceService.cs
+++ b/src/Services/src/DataPersistence/IDataPersistenceService.cs
@@ -1,0 +1,8 @@
+﻿namespace Tanzu.Toolkit.Services.DataPersistence
+{
+    public interface IDataPersistenceService
+    {
+        string ReadStringData(string key);
+        bool WriteStringData(string key, string value);
+    }
+}

--- a/src/ViewModels/test/ViewModelTestSupport.cs
+++ b/src/ViewModels/test/ViewModelTestSupport.cs
@@ -8,6 +8,7 @@ using Tanzu.Toolkit.Models;
 using Tanzu.Toolkit.Services;
 using Tanzu.Toolkit.Services.CloudFoundry;
 using Tanzu.Toolkit.Services.CommandProcess;
+using Tanzu.Toolkit.Services.DataPersistence;
 using Tanzu.Toolkit.Services.Dialog;
 using Tanzu.Toolkit.Services.ErrorDialog;
 using Tanzu.Toolkit.Services.File;
@@ -33,6 +34,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         protected Mock<IFileService> MockFileService { get; set; }
         protected Mock<ITasExplorerViewModel> MockTasExplorerViewModel { get; set; }
         protected Mock<ISerializationService> MockSerializationService { get; set; }
+        protected Mock<IDataPersistenceService> MockDataPersistenceService { get; set; }
 
         protected const string FakeCfName = "fake cf name";
         protected const string FakeCfApiAddress = "http://fake.api.address";
@@ -202,6 +204,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             MockFileService = new Mock<IFileService>();
             MockTasExplorerViewModel = new Mock<ITasExplorerViewModel>();
             MockSerializationService = new Mock<ISerializationService>();
+            MockDataPersistenceService = new Mock<IDataPersistenceService>();
 
             MockLogger = new Mock<ILogger>();
             MockLoggingService.SetupGet(m => m.Logger).Returns(MockLogger.Object);
@@ -216,6 +219,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             services.AddSingleton(MockTasExplorerViewModel.Object);
             services.AddSingleton(MockFileService.Object);
             services.AddSingleton(MockSerializationService.Object);
+            services.AddSingleton(MockDataPersistenceService.Object);
 
             Services = services.BuildServiceProvider();
         }

--- a/src/VisualStudioExtension/src/Services/DataPersistenceService.cs
+++ b/src/VisualStudioExtension/src/Services/DataPersistenceService.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.Settings;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Settings;
 using Serilog;
 using System;
@@ -16,9 +17,10 @@ namespace Tanzu.Toolkit.VisualStudio.Services
         private WritableSettingsStore _writableSettingsStore;
         private ILogger _logger;
 
-        public DataPersistenceService(IServiceProvider services)
+        public DataPersistenceService(IServiceProvider VsPackage, IServiceProvider services)
         {
-            var settingsManager = new ShellSettingsManager(services);
+            var settingsManager = new ShellSettingsManager(VsPackage);
+
             _readOnlySettingsStore = settingsManager.GetReadOnlySettingsStore(SettingsScope.UserSettings);
             _writableSettingsStore = settingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
 

--- a/src/VisualStudioExtension/src/Services/DataPersistenceService.cs
+++ b/src/VisualStudioExtension/src/Services/DataPersistenceService.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.Settings;
+using Microsoft.VisualStudio.Shell.Settings;
+using Serilog;
+using System;
+using Tanzu.Toolkit.Services.DataPersistence;
+using Tanzu.Toolkit.Services.Logging;
+
+namespace Tanzu.Toolkit.VisualStudio.Services
+{
+    public class DataPersistenceService : IDataPersistenceService
+    {
+        private const string tasCollectionPath = @"Tanzu Application Service";
+
+        private SettingsStore _readOnlySettingsStore;
+        private WritableSettingsStore _writableSettingsStore;
+        private ILogger _logger;
+
+        public DataPersistenceService(IServiceProvider services)
+        {
+            var settingsManager = new ShellSettingsManager(services);
+            _readOnlySettingsStore = settingsManager.GetReadOnlySettingsStore(SettingsScope.UserSettings);
+            _writableSettingsStore = settingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
+
+            var logSvc = services.GetRequiredService<ILoggingService>();
+            _logger = logSvc.Logger;
+        }
+
+        public string ReadStringData(string key)
+        {
+            try
+            {
+                if (!_readOnlySettingsStore.CollectionExists(tasCollectionPath))
+                {
+                    _logger.Error($"Attempted to read user settings store value under \"{tasCollectionPath}\" but no such collection path exists");
+
+                    return null;
+                }
+
+                if (_readOnlySettingsStore.PropertyExists(tasCollectionPath, key))
+                {
+                    return _readOnlySettingsStore.GetString(tasCollectionPath, key);
+                }
+                else
+                {
+                    _logger.Error($"Attempted to read user settings store value for \"{key}\" but no such property exists");
+
+                    return null;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex.Message);
+
+                return null;
+            }
+        }
+
+        public bool WriteStringData(string key, string value)
+        {
+            try
+            {
+                if (!_writableSettingsStore.CollectionExists(tasCollectionPath))
+                {
+                    _writableSettingsStore.CreateCollection(tasCollectionPath);
+                }
+
+                _writableSettingsStore.SetString(tasCollectionPath, key, value);
+
+                if (_writableSettingsStore.PropertyExists(tasCollectionPath, key))
+                {
+                    return true;
+                }
+                else
+                {
+                    throw new Exception($"Tried to write value \"{value}\" to user settings store property \"{key}\" but no such property existed after writing.");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex.Message);
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
+++ b/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
@@ -46,6 +46,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Services\DataPersistenceService.cs" />
     <Compile Include="Services\IThemeService.cs" />
     <Compile Include="Services\ThemeService.cs" />
     <Compile Include="Services\ErrorDialogService.cs" />

--- a/src/VisualStudioExtension/src/TanzuToolkitForVisualStudioPackage.cs
+++ b/src/VisualStudioExtension/src/TanzuToolkitForVisualStudioPackage.cs
@@ -10,6 +10,7 @@ using Tanzu.Toolkit.Services;
 using Tanzu.Toolkit.Services.CfCli;
 using Tanzu.Toolkit.Services.CloudFoundry;
 using Tanzu.Toolkit.Services.CommandProcess;
+using Tanzu.Toolkit.Services.DataPersistence;
 using Tanzu.Toolkit.Services.Dialog;
 using Tanzu.Toolkit.Services.ErrorDialog;
 using Tanzu.Toolkit.Services.File;
@@ -125,6 +126,7 @@ namespace Tanzu.Toolkit.VisualStudio
             services.AddSingleton<IThemeService>(new ThemeService());
             services.AddTransient<ICommandProcessService, CommandProcessService>();
             services.AddSingleton<ISerializationService, SerializationService>();
+            services.AddSingleton<IDataPersistenceService, DataPersistenceService>();
 
             /* Tool Windows */
             services.AddTransient<TanzuTasExplorerToolWindow>();

--- a/src/VisualStudioExtension/src/TanzuToolkitForVisualStudioPackage.cs
+++ b/src/VisualStudioExtension/src/TanzuToolkitForVisualStudioPackage.cs
@@ -126,7 +126,7 @@ namespace Tanzu.Toolkit.VisualStudio
             services.AddSingleton<IThemeService>(new ThemeService());
             services.AddTransient<ICommandProcessService, CommandProcessService>();
             services.AddSingleton<ISerializationService, SerializationService>();
-            services.AddSingleton<IDataPersistenceService, DataPersistenceService>();
+            services.AddSingleton<IDataPersistenceService>(provider => new DataPersistenceService(this, provider));
 
             /* Tool Windows */
             services.AddTransient<TanzuTasExplorerToolWindow>();


### PR DESCRIPTION
Here's a vid showing that connection persistence works when the extension is installed into a _real_ instance of Visual Studio. There's a caveat here: when using an _experimental_ instance of VS, the CfInstanceViewModel is successfully restored but attempts to use that restored connection fail due to an unobtainable access token. This seems to be happening because the `.cf` directory (which keeps a hold of CF CLI state, including tokens) does _not_ persist between sessions of the _experimental_ VS instance (unlike it does for _real_ VS instances, as shown in this video). 

I'm surprised to have seen the `.cf` directory be destroyed & recreated between sessions of the experimental VS instance, given that [we've seen it persist in the past](https://github.com/vmware-tanzu/tanzu-toolkit-for-visual-studio/issues/110#issuecomment-964311417)... not sure what's changed, but at least the feature works where it needs to! 

If we want the experimental VS instance to behave like we're seeing real VS instances behave w.r.t. login persistence, we have the option to persist the CF API access token in the VS user settings store (like these changes do for the TAS connection name & api address) & no longer rely on the `.cf` directory `config.json` store for access tokens. This might take some non-trivial refactoring work though.

https://user-images.githubusercontent.com/22666145/144334067-3dce303e-5e97-4891-b656-a163a80b0d04.mp4


