### PR TITLE
Reduce noise in diagnostic log files

### DIFF
--- a/src/ViewModels/src/AbstractViewModel.cs
+++ b/src/ViewModels/src/AbstractViewModel.cs
@@ -72,10 +72,6 @@ namespace Tanzu.Toolkit.ViewModels
             {
                 handler(this, new PropertyChangedEventArgs(propertyName));
             }
-            else
-            {
-                Logger.Debug("Detected null PropertyChanged handler; is there a subscriber for the event '{EventPropertyName}'?", propertyName);
-            }
         }
     }
 }


### PR DESCRIPTION
e9401958 added a log statement (debug level) for every time the property changed event handler was found to be null in the AbstractViewModel class. This generated **lots** of log statements (e.g. 1 per tree view item in the TAS Explorer per refresh cycle (default is 10 sec)). These logs feel like clutter since they're generated repeatedly & don't help diagnose any significant issue. Removing this log statement will help keep log files small & readable.
![image](https://user-images.githubusercontent.com/22666145/148974045-ab39f088-de25-4d5c-87c6-13524dea2f6b.png)
