### PR TITLE
Support manifests that use single-buildpack format

### DIFF
--- a/src/Models/src/AppManifest.cs
+++ b/src/Models/src/AppManifest.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using YamlDotNet.Serialization;
 
 namespace Tanzu.Toolkit.Models
 {
     public class AppManifest
     {
         public int Version { get; set; }
+
         public List<AppConfig> Applications { get; set; }
 
         public AppManifest DeepClone()
@@ -22,6 +25,30 @@ namespace Tanzu.Toolkit.Models
                 Version = Version,
                 Applications = appsList,
             };
+        }
+
+        [YamlIgnore]
+        public BuildpackScheme OriginalBuildpackScheme { get; set; }
+
+        [YamlIgnore]
+        public AppConfig App
+        {
+            get
+            {
+                var manifestApp = Applications.FirstOrDefault();
+                if (manifestApp == null)
+                {
+                    throw new ArgumentException("No app specification detected in manifest");
+                }
+
+                return manifestApp;
+            }
+        }
+
+        public enum BuildpackScheme
+        {
+            Singular = 0,
+            List = 1,
         }
     }
 

--- a/src/Models/src/AppManifest.cs
+++ b/src/Models/src/AppManifest.cs
@@ -27,6 +27,7 @@ namespace Tanzu.Toolkit.Models
 
     public class AppConfig : ICloneable
     {
+        public string Buildpack { get; set; }
         public List<string> Buildpacks { get; set; }
         public string Command { get; set; }
         public string DiskQuota { get; set; }

--- a/src/Models/src/Tanzu.Toolkit.Models.csproj
+++ b/src/Models/src/Tanzu.Toolkit.Models.csproj
@@ -6,4 +6,8 @@
     <RootNamespace>Tanzu.Toolkit.Models</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="YamlDotNet" Version="11.2.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/Services/src/Serialization/SerializationService.cs
+++ b/src/Services/src/Serialization/SerializationService.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Tanzu.Toolkit.Models;
 using YamlDotNet.Serialization;
 
@@ -40,7 +38,9 @@ namespace Tanzu.Toolkit.Services
         public string SerializeCfAppManifest(AppManifest manifest)
         {
             var manifestApp = manifest.App;
-            if (manifestApp.Buildpacks != null && manifestApp.Buildpacks.Count == 1 && manifest.OriginalBuildpackScheme == AppManifest.BuildpackScheme.Singular)
+            if (manifestApp.Buildpacks != null
+                && manifestApp.Buildpacks.Count == 1
+                && manifest.OriginalBuildpackScheme == AppManifest.BuildpackScheme.Singular)
             {
                 ReformatBuildpacksListAsSingularBuildpack(manifest, manifestApp.Buildpacks[0]);
             }

--- a/src/Services/src/Tanzu.Toolkit.Services.csproj
+++ b/src/Services/src/Tanzu.Toolkit.Services.csproj
@@ -1,23 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>Tanzu.Toolkit.Services</RootNamespace>
-    <AssemblyName>Tanzu.Toolkit.Services</AssemblyName>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<RootNamespace>Tanzu.Toolkit.Services</RootNamespace>
+		<AssemblyName>Tanzu.Toolkit.Services</AssemblyName>
+		<LangVersion>8.0</LangVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.16.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.2" />
-    <PackageReference Include="YamlDotNet" Version="11.2.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+		<PackageReference Include="Serilog" Version="2.10.0" />
+		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.16.0" />
+		<PackageReference Include="System.Text.Json" Version="6.0.2" />
+		<PackageReference Include="YamlDotNet" Version="11.2.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\CloudFoundryApiClient\src\Tanzu.Toolkit.CloudFoundryApiClient.csproj" />
-    <ProjectReference Include="..\..\Models\src\Tanzu.Toolkit.Models.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\CloudFoundryApiClient\src\Tanzu.Toolkit.CloudFoundryApiClient.csproj" />
+		<ProjectReference Include="..\..\Models\src\Tanzu.Toolkit.Models.csproj" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Previously, only manifests specifying `buildpacks` would parse properly. Now, manifests that specify `buildpack` (singular) are parseable -- they get converted to a list behind the scenes in case multiple buildpacks are selected later, but if not, the single buildpack is reserialized as `buildpack` just like the original
![manifest-parsing-bug-#280](https://user-images.githubusercontent.com/22666145/157340125-9f8e86d1-f535-4d73-9182-d84b19d47ad1.gif)

fixes #280 