### PR TITLE
Improve login api address error display

### DIFF
--- a/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
+++ b/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
@@ -98,6 +98,7 @@
     </Compile>
     <Compile Include="Views\Converters\ListToStringConverter.cs" />
     <Compile Include="Views\Converters\PageNumberConverter.cs" />
+    <Compile Include="Views\Converters\StringNullVisibilityConverter.cs" />
     <Compile Include="Views\Converters\VisibilityConverter.cs" />
     <Compile Include="Views\IOutputView.cs" />
     <Compile Include="Views\IAppDeletionConfirmationView.cs" />

--- a/src/VisualStudioExtension/src/Views/Converters/StringNullVisibilityConverter.cs
+++ b/src/VisualStudioExtension/src/Views/Converters/StringNullVisibilityConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Tanzu.Toolkit.VisualStudio.Views.Converters
+{
+    public class StringNullVisibilityConverter : IValueConverter
+    {
+        public bool Reversed { get; set; }
+        public bool ReserveSpace { get; set; }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return string.IsNullOrWhiteSpace(value as string)
+                ? Reversed ? Visibility.Visible : ReserveSpace ? Visibility.Hidden : (object)Visibility.Collapsed
+                : Reversed ? ReserveSpace ? Visibility.Hidden : (object)Visibility.Collapsed : Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new InvalidOperationException("Visibility Converter can only be used OneWay.");
+        }
+    }
+}

--- a/src/VisualStudioExtension/src/Views/LoginView.xaml
+++ b/src/VisualStudioExtension/src/Views/LoginView.xaml
@@ -23,6 +23,7 @@
         <converters:VisibilityConverter x:Key="Visibility" />
         <converters:VisibilityConverter x:Key="CollapsedVisibility" ReserveSpace="False" />
         <converters:VisibilityConverter x:Key="InverseCollapsedVisibility" ReserveSpace="False" Reversed="True"/>
+        <converters:StringNullVisibilityConverter x:Key="StringNullVisibility" ReserveSpace="False" Reversed="False"/>
         <converters:PageNumberConverter x:Key="Page1Displayer" ShowValue="1" ReserveSpace="False"/>
         <converters:PageNumberConverter x:Key="Page2Displayer" ShowValue="2" ReserveSpace="False"/>
         <converters:PageNumberConverter x:Key="Page3Displayer" ShowValue="3" ReserveSpace="False"/>
@@ -114,6 +115,7 @@
 
                 <TextBlock
                     Text="{Binding ApiAddressError}"
+                    Visibility="{Binding ApiAddressError, Converter={StaticResource StringNullVisibility}}"
                     Foreground="Red"
                     TextWrapping="Wrap"
                     Grid.Row="1" />


### PR DESCRIPTION
- only show api address error text when there's an error; don't show blank space where the error would go if there's no error (collapse the whitespace)