### PR TITLE
Misc error handling improvements

### DIFF
--- a/src/CloudFoundryApiClient/src/Tanzu.Toolkit.CloudFoundryApiClient.csproj
+++ b/src/CloudFoundryApiClient/src/Tanzu.Toolkit.CloudFoundryApiClient.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.3" />
   </ItemGroup>
 

--- a/src/CloudFoundryApiClient/src/Tanzu.Toolkit.CloudFoundryApiClient.csproj
+++ b/src/CloudFoundryApiClient/src/Tanzu.Toolkit.CloudFoundryApiClient.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/CloudFoundryApiClient/src/Tanzu.Toolkit.CloudFoundryApiClient.csproj
+++ b/src/CloudFoundryApiClient/src/Tanzu.Toolkit.CloudFoundryApiClient.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.3" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CloudFoundryApiClient/test/Tanzu.Toolkit.CloudFoundryApiClient.Tests.csproj
+++ b/src/CloudFoundryApiClient/test/Tanzu.Toolkit.CloudFoundryApiClient.Tests.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CloudFoundryApiClient/test/Tanzu.Toolkit.CloudFoundryApiClient.Tests.csproj
+++ b/src/CloudFoundryApiClient/test/Tanzu.Toolkit.CloudFoundryApiClient.Tests.csproj
@@ -12,9 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Services/src/CfCli/CfCliService.cs
+++ b/src/Services/src/CfCli/CfCliService.cs
@@ -58,9 +58,17 @@ namespace Tanzu.Toolkit.Services.CfCli
         {
             ConfigFilePath = configFilePath;
             Services = services;
-            _fileService = services.GetRequiredService<IFileService>();
-            var logSvc = services.GetRequiredService<ILoggingService>();
-            _logger = logSvc.Logger;
+
+            try
+            {
+                var logSvc = services.GetRequiredService<ILoggingService>();
+                _logger = logSvc.Logger;
+                _fileService = services.GetRequiredService<IFileService>();
+            }
+            catch (Exception ex)
+            {
+                _logger?.Error("Unable to construct {ClassName} due to an unattainable service: {ServiceException}", nameof(CfCliService), ex);
+            }
         }
 
         /// <summary>

--- a/src/Services/src/CloudFoundry/CloudFoundryService.cs
+++ b/src/Services/src/CloudFoundry/CloudFoundryService.cs
@@ -37,14 +37,21 @@ namespace Tanzu.Toolkit.Services.CloudFoundry
 
         public CloudFoundryService(IServiceProvider services)
         {
-            _cfApiClient = services.GetRequiredService<ICfApiClient>();
-            _cfCliService = services.GetRequiredService<ICfCliService>();
-            _fileService = services.GetRequiredService<IFileService>();
-            _dialogService = services.GetRequiredService<IErrorDialog>();
-            _serializationService = services.GetRequiredService<ISerializationService>();
+            try
+            {
+                var logSvc = services.GetRequiredService<ILoggingService>();
+                _logger = logSvc.Logger;
 
-            var logSvc = services.GetRequiredService<ILoggingService>();
-            _logger = logSvc.Logger;
+                _cfApiClient = services.GetRequiredService<ICfApiClient>();
+                _cfCliService = services.GetRequiredService<ICfCliService>();
+                _fileService = services.GetRequiredService<IFileService>();
+                _dialogService = services.GetRequiredService<IErrorDialog>();
+                _serializationService = services.GetRequiredService<ISerializationService>();
+            }
+            catch (Exception ex)
+            {
+                _logger?.Error("Unable to construct {ClassName} due to an unattainable service: {ServiceException}", nameof(CloudFoundryService), ex);
+            }
         }
 
         internal string CfApiAddress { get; set; }

--- a/src/Services/src/Tanzu.Toolkit.Services.csproj
+++ b/src/Services/src/Tanzu.Toolkit.Services.csproj
@@ -9,9 +9,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-		<PackageReference Include="Serilog" Version="2.10.0" />
+		<PackageReference Include="Serilog" Version="2.11.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.16.0" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.17.0" />
 		<PackageReference Include="System.Text.Json" Version="6.0.3" />
 		<PackageReference Include="YamlDotNet" Version="11.2.1" />
 	</ItemGroup>

--- a/src/Services/src/Tanzu.Toolkit.Services.csproj
+++ b/src/Services/src/Tanzu.Toolkit.Services.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="Serilog" Version="2.11.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.17.0" />
-		<PackageReference Include="System.Text.Json" Version="6.0.3" />
+		<PackageReference Include="System.Text.Json" Version="6.0.0" />
 		<PackageReference Include="YamlDotNet" Version="11.2.1" />
 	</ItemGroup>
 

--- a/src/Services/src/Tanzu.Toolkit.Services.csproj
+++ b/src/Services/src/Tanzu.Toolkit.Services.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="Serilog" Version="2.10.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.16.0" />
-		<PackageReference Include="System.Text.Json" Version="6.0.2" />
+		<PackageReference Include="System.Text.Json" Version="6.0.3" />
 		<PackageReference Include="YamlDotNet" Version="11.2.1" />
 	</ItemGroup>
 

--- a/src/Services/test/Tanzu.Toolkit.Services.Tests.csproj
+++ b/src/Services/test/Tanzu.Toolkit.Services.Tests.csproj
@@ -13,9 +13,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ViewModels/src/AbstractViewModel.cs
+++ b/src/ViewModels/src/AbstractViewModel.cs
@@ -24,15 +24,23 @@ namespace Tanzu.Toolkit.ViewModels
         public AbstractViewModel(IServiceProvider services)
         {
             Services = services;
-            DialogService = services.GetRequiredService<IDialogService>();
-            ViewLocatorService = services.GetRequiredService<IViewLocatorService>();
-            ThreadingService = services.GetRequiredService<IThreadingService>();
-            UiDispatcherService = services.GetRequiredService<IUiDispatcherService>();
-            FileService = services.GetRequiredService<IFileService>();
-            SerializationService = services.GetRequiredService<ISerializationService>();
-            ErrorService = services.GetRequiredService<IErrorDialog>();
-            var logSvc = services.GetRequiredService<ILoggingService>();
-            Logger = logSvc.Logger;
+
+            try
+            {
+                var logSvc = services.GetRequiredService<ILoggingService>();
+                Logger = logSvc.Logger;
+                DialogService = services.GetRequiredService<IDialogService>();
+                ViewLocatorService = services.GetRequiredService<IViewLocatorService>();
+                ThreadingService = services.GetRequiredService<IThreadingService>();
+                UiDispatcherService = services.GetRequiredService<IUiDispatcherService>();
+                FileService = services.GetRequiredService<IFileService>();
+                SerializationService = services.GetRequiredService<ISerializationService>();
+                ErrorService = services.GetRequiredService<IErrorDialog>();
+            }
+            catch (Exception ex)
+            {
+                Logger?.Error("Unable to construct {ClassName} due to an unattainable service: {ServiceException}", nameof(AbstractViewModel), ex);
+            }
         }
 
         public IServiceProvider Services { get; }

--- a/src/ViewModels/src/AppDeletionConfirmation/AppDeletionConfirmationViewModel.cs
+++ b/src/ViewModels/src/AppDeletionConfirmation/AppDeletionConfirmationViewModel.cs
@@ -54,7 +54,16 @@ namespace Tanzu.Toolkit.ViewModels.AppDeletionConfirmation
         public void ShowConfirmation(CloudFoundryApp app)
         {
             CfApp = app;
-            DialogService.ShowDialog(nameof(AppDeletionConfirmationViewModel));
+            var dialog = DialogService.ShowDialog(nameof(AppDeletionConfirmationViewModel));
+            if (dialog == null)
+            {
+                Logger?.Error("{ClassName}.{MethodName} encountered null DialogResult, indicating that something went wrong trying to construct the view.", nameof(AppDeletionConfirmation), nameof(ShowConfirmation));
+                var title = "Something went wrong while trying to display app deletion confirmation";
+                var msg = "View construction failed"+
+                    Environment.NewLine + Environment.NewLine +
+                    "If this issue persists, please contact tas-vs-extension@vmware.com";
+                ErrorService.DisplayErrorDialog(title, msg);
+            }
             CfApp = null;
         }
 

--- a/src/ViewModels/src/Login/LoginViewModel.cs
+++ b/src/ViewModels/src/Login/LoginViewModel.cs
@@ -35,7 +35,6 @@ namespace Tanzu.Toolkit.ViewModels
         {
             IsApiAddressFormatValid = false;
             _tasExplorer = services.GetRequiredService<ITasExplorerViewModel>();
-            CfClient = Services.GetRequiredService<ICloudFoundryService>();
         }
 
         // Properties //

--- a/src/ViewModels/src/Login/LoginViewModel.cs
+++ b/src/ViewModels/src/Login/LoginViewModel.cs
@@ -27,14 +27,12 @@ namespace Tanzu.Toolkit.ViewModels
         private bool _connectingToCf = false;
         private bool _isApiAddressFormatValid;
         private bool _certificateInvalid = false;
-        internal ITasExplorerViewModel _tasExplorer;
         private string _ssoLink;
 
         public LoginViewModel(IServiceProvider services)
             : base(services)
         {
             IsApiAddressFormatValid = false;
-            _tasExplorer = services.GetRequiredService<ITasExplorerViewModel>();
         }
 
         // Properties //
@@ -314,7 +312,7 @@ namespace Tanzu.Toolkit.ViewModels
             if (result.Succeeded)
             {
                 ErrorMessage = null;
-                _tasExplorer.SetConnection(TargetCf);
+                TasExplorer.SetConnection(TargetCf);
                 DialogService.CloseDialog(arg, true);
                 PageNum = 1;
                 ClearPassword();
@@ -343,7 +341,7 @@ namespace Tanzu.Toolkit.ViewModels
 
                 if (loginResult.Succeeded)
                 {
-                    _tasExplorer.SetConnection(TargetCf);
+                    TasExplorer.SetConnection(TargetCf);
                     CloseDialog();
                 }
                 else

--- a/src/ViewModels/src/Tanzu.Toolkit.ViewModels.csproj
+++ b/src/ViewModels/src/Tanzu.Toolkit.ViewModels.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ViewModels/src/Tanzu.Toolkit.ViewModels.csproj
+++ b/src/ViewModels/src/Tanzu.Toolkit.ViewModels.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ViewModels/src/TasExplorer/TasExplorerViewModel.cs
+++ b/src/ViewModels/src/TasExplorer/TasExplorerViewModel.cs
@@ -227,8 +227,16 @@ namespace Tanzu.Toolkit.ViewModels
             }
             else
             {
-                DialogService.ShowDialog(typeof(LoginViewModel).Name);
-
+                var dialog = DialogService.ShowDialog(nameof(LoginViewModel));
+                if (dialog == null)
+                {
+                    Logger?.Error("{ClassName}.{MethodName} encountered null DialogResult, indicating that something went wrong trying to construct the view.", nameof(TasExplorerViewModel), nameof(OpenLoginView));
+                    var title = "Something went wrong while trying to display login window";
+                    var msg = "View construction failed" +
+                        Environment.NewLine + Environment.NewLine +
+                        "If this issue persists, please contact tas-vs-extension@vmware.com";
+                    ErrorService.DisplayErrorDialog(title, msg);
+                }
             }
         }
 

--- a/src/ViewModels/test/Tanzu.Toolkit.ViewModels.Tests.csproj
+++ b/src/ViewModels/test/Tanzu.Toolkit.ViewModels.Tests.csproj
@@ -12,14 +12,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/VisualStudioExtension/src/Services/DialogService.cs
+++ b/src/VisualStudioExtension/src/Services/DialogService.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Serilog;
 using System;
 using System.Windows;
 using Tanzu.Toolkit.Services.Dialog;
+using Tanzu.Toolkit.Services.Logging;
 using Tanzu.Toolkit.Services.ViewLocator;
 
 namespace Tanzu.Toolkit.VisualStudio.Services
@@ -9,11 +11,14 @@ namespace Tanzu.Toolkit.VisualStudio.Services
     public class DialogService : IDialogService
     {
         private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger _logger;
         private readonly IViewLocatorService _viewLocatorService;
 
         public DialogService(IServiceProvider serviceProvider)
         {
             _serviceProvider = serviceProvider;
+            var loggingSvc = _serviceProvider.GetRequiredService<ILoggingService>();
+            _logger = loggingSvc.Logger;
             _viewLocatorService = _serviceProvider.GetRequiredService<IViewLocatorService>();
         }
 
@@ -25,7 +30,11 @@ namespace Tanzu.Toolkit.VisualStudio.Services
 
         public IDialogResult ShowDialog(string dialogName, object parameter = null)
         {
-            var dialog = _viewLocatorService.GetViewByViewModelName(dialogName, parameter) as DependencyObject;
+            if (!(_viewLocatorService.GetViewByViewModelName(dialogName, parameter) is DependencyObject dialog))
+            {
+                _logger?.Error("{ClassName} failed to show dialog for {DialogName}; {MethodName} returned null", nameof(DialogService), dialogName, nameof(_viewLocatorService.GetViewByViewModelName));
+                return null;
+            }
             var dialogWindow = Window.GetWindow(dialog);
             var result = dialogWindow.ShowDialog();
             return new DialogResult() { Result = result };

--- a/src/VisualStudioExtension/src/Services/VsViewLocatorService.cs
+++ b/src/VisualStudioExtension/src/Services/VsViewLocatorService.cs
@@ -37,7 +37,14 @@ namespace Tanzu.Toolkit.VisualStudio.Services
                 }
                 else
                 {
-                    view = ServiceProvider.GetService(type);
+                    try
+                    {
+                        view = ServiceProvider.GetService(type);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger?.Error("Caught exception in {ClassName}.{MethodName} thrown because of an unattainable service: {ServiceException}", nameof(VsViewLocatorService), nameof(GetViewByViewModelName), ex);
+                    }
                 }
 
                 return view;

--- a/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
+++ b/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
@@ -180,10 +180,10 @@
       <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-      <Version>6.0.0</Version>
+      <Version>6.0.1</Version>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable">
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
+++ b/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
@@ -179,9 +179,6 @@
     <PackageReference Include="Microsoft.Extensions.Http">
       <Version>6.0.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-      <Version>6.0.1</Version>
-    </PackageReference>
     <PackageReference Include="System.Collections.Immutable">
       <Version>6.0.0</Version>
     </PackageReference>

--- a/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
+++ b/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
@@ -59,7 +59,7 @@
         </None>
         <!-- <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime" /> -->
         <PackageReference Include="Community.VisualStudio.Toolkit.16">
-          <Version>16.0.394</Version>
+          <Version>16.0.430</Version>
         </PackageReference>
       </ItemGroup>
     </Otherwise>

--- a/src/VisualStudioExtension/src/TanzuToolkitForVisualStudioPackage.cs
+++ b/src/VisualStudioExtension/src/TanzuToolkitForVisualStudioPackage.cs
@@ -89,20 +89,27 @@ namespace Tanzu.Toolkit.VisualStudio
 
         protected override object GetService(Type serviceType)
         {
-            if (_serviceProvider == null)
+            try
             {
-                var collection = new ServiceCollection();
-                ConfigureServices(collection);
-                _serviceProvider = collection.BuildServiceProvider();
-            }
+                if (_serviceProvider == null)
+                {
+                    var collection = new ServiceCollection();
+                    ConfigureServices(collection);
+                    _serviceProvider = collection.BuildServiceProvider();
+                }
 
-            var result = _serviceProvider.GetService(serviceType);
-            if (result != null)
+                var result = _serviceProvider.GetService(serviceType);
+                if (result != null)
+                {
+                    return result;
+                }
+
+                return base.GetService(serviceType);
+            }
+            catch (Exception)
             {
-                return result;
+                return null;
             }
-
-            return base.GetService(serviceType);
         }
 
         protected override WindowPane InstantiateToolWindow(Type toolWindowType)

--- a/src/VisualStudioExtension/test/Tanzu.Toolkit.VisualStudioExtension.Tests/Tanzu.Toolkit.VisualStudioExtension.Tests.csproj
+++ b/src/VisualStudioExtension/test/Tanzu.Toolkit.VisualStudioExtension.Tests/Tanzu.Toolkit.VisualStudioExtension.Tests.csproj
@@ -8,15 +8,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is a collection of changes intended to:
- prevent VS from crashing when exceptions thrown in VS 2019 regarding `System.Text.Json` and `Microsoft.Extensions.Logging.Abstractions`
- catch & log exceptions thrown as a result of failed attempts to acquire services in constructors
- make small code health simplifications
- standardize the user experience for windows which fail to render as a result of `Community.VisualStudio.Toolkit.UseVsTheme`
    - new behavior is to log error & show error pop-up describing why the window failed to render after the click
    - these windows are:
        - LoginView
        - RemoteDebugView
        - DeploymentDialogView
        - AppDeletionConfirmationView