### PR TITLE
Fix bug that prevented certain views from displaying in VS 2019

### DIFF
--- a/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
+++ b/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
@@ -59,7 +59,7 @@
         </None>
         <!-- <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime" /> -->
         <PackageReference Include="Community.VisualStudio.Toolkit.16">
-          <Version>16.0.430</Version>
+          <Version>16.0.394</Version>
         </PackageReference>
       </ItemGroup>
     </Otherwise>


### PR DESCRIPTION
The impacted views were those that set `toolkit:Themes.UseVsTheme="True"`:
- Login
- Deployment
- RemoteDebug
- AppDeletionConfirmation

This seems to be a bug that was introduced in `Community.VisualStudio.Toolkit 16.0.430`; calling `InitializeComponent` on a xaml control that uses this feature throws exception: 
```
System.Windows.Markup.XamlParseException: 'Initialization of 'Tanzu.Toolkit.VisualStudio.Views.LoginView' threw an exception.' Line number '374' and line position '7'. ---> System.IO.IOException: Cannot locate resource 'themes/themeresources.xaml'
```

Reverting to version `16.0.394` seems to allow views to render properly.
fixes #312 