### PR TITLE
Fix sso passcode bug

### DIFF
--- a/src/ViewModels/src/Login/LoginViewModel.cs
+++ b/src/ViewModels/src/Login/LoginViewModel.cs
@@ -28,6 +28,7 @@ namespace Tanzu.Toolkit.ViewModels
         private bool _isApiAddressFormatValid;
         private bool _certificateInvalid = false;
         private string _ssoLink;
+        private string _ssoPasscode;
 
         public LoginViewModel(IServiceProvider services)
             : base(services)
@@ -180,7 +181,15 @@ namespace Tanzu.Toolkit.ViewModels
 
         public Func<bool> PasswordEmpty { get; set; }
 
-        public string SsoPasscode { get; set; }
+        public string SsoPasscode
+        {
+            get => _ssoPasscode;
+            set
+            {
+                _ssoPasscode = value;
+                RaisePropertyChangedEvent("SsoPasscode");
+            }
+        }
 
         // Methods //
 


### PR DESCRIPTION
SSO passcode wasn't previously updating state properly, resulting in an incorrect error about the passcode field being empty