### PR TITLE
Display dialog windows as modals

### DIFF
--- a/src/Services/src/Dialog/IDialogService.cs
+++ b/src/Services/src/Dialog/IDialogService.cs
@@ -2,9 +2,8 @@
 {
     public interface IDialogService
     {
-        IDialogResult ShowDialog(string dialogViewModel, object parameter = null);
-
         void CloseDialog(object dialogWindow, bool result);
         void CloseDialogByName(string dialogName, object parameter = null);
+        IDialogResult ShowModal(string dialogName, object parameter = null);
     }
 }

--- a/src/ViewModels/src/AbstractViewModel.cs
+++ b/src/ViewModels/src/AbstractViewModel.cs
@@ -82,7 +82,7 @@ namespace Tanzu.Toolkit.ViewModels
                     if (TasExplorer.TasConnection == null)
                     {
                         Logger.Information("Detected null TAS connection in AbstractViewModel; prompting login");
-                        DialogService.ShowDialog(typeof(LoginViewModel).Name);
+                        DialogService.ShowModal(typeof(LoginViewModel).Name);
                     }
                     _cfClient = TasExplorer.TasConnection?.CfClient;
                     if (_cfClient == null)

--- a/src/ViewModels/src/AppDeletionConfirmation/AppDeletionConfirmationViewModel.cs
+++ b/src/ViewModels/src/AppDeletionConfirmation/AppDeletionConfirmationViewModel.cs
@@ -54,7 +54,7 @@ namespace Tanzu.Toolkit.ViewModels.AppDeletionConfirmation
         public void ShowConfirmation(CloudFoundryApp app)
         {
             CfApp = app;
-            var dialog = DialogService.ShowDialog(nameof(AppDeletionConfirmationViewModel));
+            var dialog = DialogService.ShowModal(nameof(AppDeletionConfirmationViewModel));
             if (dialog == null)
             {
                 Logger?.Error("{ClassName}.{MethodName} encountered null DialogResult, indicating that something went wrong trying to construct the view.", nameof(AppDeletionConfirmation), nameof(ShowConfirmation));

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -408,7 +408,7 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             deploymentViewModel.IsLoggedIn = tasExplorer.TasConnection != null;
             deploymentViewModel.Expanded = false;
             deploymentViewModel.ConfigureForRemoteDebugging = true;
-            DialogService.ShowDialog(nameof(DeploymentDialogViewModel));
+            DialogService.ShowModal(nameof(DeploymentDialogViewModel));
 
             if (deploymentViewModel.DeploymentInProgress)
             {

--- a/src/ViewModels/src/TasExplorer/TasExplorerViewModel.cs
+++ b/src/ViewModels/src/TasExplorer/TasExplorerViewModel.cs
@@ -227,7 +227,7 @@ namespace Tanzu.Toolkit.ViewModels
             }
             else
             {
-                var dialog = DialogService.ShowDialog(nameof(LoginViewModel));
+                var dialog = DialogService.ShowModal(nameof(LoginViewModel));
                 if (dialog == null)
                 {
                     Logger?.Error("{ClassName}.{MethodName} encountered null DialogResult, indicating that something went wrong trying to construct the view.", nameof(TasExplorerViewModel), nameof(OpenLoginView));

--- a/src/ViewModels/test/AppDeletionConfirmationViewModelTests.cs
+++ b/src/ViewModels/test/AppDeletionConfirmationViewModelTests.cs
@@ -43,7 +43,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         {
             _sut.ShowConfirmation(_fakeCfApp);
 
-            MockDialogService.Verify(ds => ds.ShowDialog(nameof(AppDeletionConfirmationViewModel), null), Times.Once);
+            MockDialogService.Verify(ds => ds.ShowModal(nameof(AppDeletionConfirmationViewModel), null), Times.Once);
         }
 
         [TestMethod]

--- a/src/ViewModels/test/TasExplorerViewModelTests.cs
+++ b/src/ViewModels/test/TasExplorerViewModelTests.cs
@@ -210,7 +210,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             _sut.OpenLoginView(null);
 
-            MockDialogService.Verify(ds => ds.ShowDialog(typeof(LoginViewModel).Name, null), Times.Once);
+            MockDialogService.Verify(ds => ds.ShowModal(typeof(LoginViewModel).Name, null), Times.Once);
         }
 
         [TestMethod]
@@ -239,7 +239,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             };
 
             MockDialogService.Setup(mock => mock.
-                ShowDialog(typeof(LoginViewModel).Name, null))
+                ShowModal(typeof(LoginViewModel).Name, null))
                     .Callback(() =>
                     {
                         // Simulate unsuccessful login by NOT setting TasConnection as LoginView would've done on a successful login
@@ -272,7 +272,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         {
             _sut.OpenDeletionView(null);
 
-            MockDialogService.Verify(ds => ds.ShowDialog(typeof(AppDeletionConfirmationViewModel).Name, null), Times.Never);
+            MockDialogService.Verify(ds => ds.ShowModal(typeof(AppDeletionConfirmationViewModel).Name, null), Times.Never);
         }
 
         [TestMethod]

--- a/src/VisualStudioExtension/src/Commands/PushToCloudFoundryCommand.cs
+++ b/src/VisualStudioExtension/src/Commands/PushToCloudFoundryCommand.cs
@@ -144,8 +144,8 @@ namespace Tanzu.Toolkit.VisualStudio.Commands
                             deploymentViewModel.IsLoggedIn = tasExplorer.TasConnection != null;
                             deploymentViewModel.Expanded = false;
 
-                            var deploymentWindow = _services.GetRequiredService<IDeploymentDialogView>() as System.Windows.Window;
-                            deploymentWindow?.ShowDialog();
+                            var deploymentWindow = _services.GetRequiredService<IDeploymentDialogView>() as Microsoft.VisualStudio.PlatformUI.DialogWindow;
+                            deploymentWindow?.ShowModal();
 
                             // * Actions to take after modal closes:
                             if (deploymentViewModel.DeploymentInProgress) // don't open tool window if modal was closed via "X" button

--- a/src/VisualStudioExtension/src/Commands/RemoteDebugCommand.cs
+++ b/src/VisualStudioExtension/src/Commands/RemoteDebugCommand.cs
@@ -188,10 +188,10 @@ namespace Tanzu.Toolkit.VisualStudio
                         });
 
                         var remoteDebugViewModel = new RemoteDebugViewModel(projectName, projectDirectory, tfm, launchFilePath, initiateDebugCallback, services: _services) as IRemoteDebugViewModel;
-                        var view = new RemoteDebugView(remoteDebugViewModel, new ThemeService());
+                        var view = new RemoteDebugView(remoteDebugViewModel, new ThemeService()) as Microsoft.VisualStudio.PlatformUI.DialogWindow;
                         remoteDebugViewModel.ViewOpener = view.Show;
                         remoteDebugViewModel.ViewCloser = view.Hide;
-                        view.ShowDialog(); // open & wait
+                        view.ShowModal(); // open & wait
                     }
                 }
             }

--- a/src/VisualStudioExtension/src/Services/DialogService.cs
+++ b/src/VisualStudioExtension/src/Services/DialogService.cs
@@ -28,15 +28,15 @@ namespace Tanzu.Toolkit.VisualStudio.Services
             asWindows.Hide();
         }
 
-        public IDialogResult ShowDialog(string dialogName, object parameter = null)
+        public IDialogResult ShowModal(string dialogName, object parameter = null)
         {
             if (!(_viewLocatorService.GetViewByViewModelName(dialogName, parameter) is DependencyObject dialog))
             {
                 _logger?.Error("{ClassName} failed to show dialog for {DialogName}; {MethodName} returned null", nameof(DialogService), dialogName, nameof(_viewLocatorService.GetViewByViewModelName));
                 return null;
             }
-            var dialogWindow = Window.GetWindow(dialog);
-            var result = dialogWindow.ShowDialog();
+            var dialogWindow = Window.GetWindow(dialog) as Microsoft.VisualStudio.PlatformUI.DialogWindow;
+            var result = dialogWindow.ShowModal();
             return new DialogResult() { Result = result };
         }
 


### PR DESCRIPTION
This prevents focus from being lost from the modal once it's open. The intent here is to reduce the change that a modal gets lost behind the main VS window (in a scenario like that, the IDE will be unresponsive for seemingly no reason)