### PR TITLE
Improve deployment dialog behavior

### DIFF
--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -120,8 +120,6 @@ namespace Tanzu.Toolkit.ViewModels
                 }
             };
 
-            SetManifestIfDefaultExists();
-
             if (_tasExplorerViewModel.TasConnection != null)
             {
                 TargetName = _tasExplorerViewModel.TasConnection.DisplayText;
@@ -136,6 +134,8 @@ namespace Tanzu.Toolkit.ViewModels
             AppName = _projectService.ProjectName;
             _projectName = _projectService.ProjectName;
             Expanded = false;
+
+            OnRendered = () => SetManifestIfDefaultExists();
 
             OnClosed = () =>
             {
@@ -554,6 +554,8 @@ namespace Tanzu.Toolkit.ViewModels
         }
 
         public Action OnClosed { get; set; }
+
+        public Action OnRendered { get; set; }
 
         public bool CanDeployApp(object arg)
         {

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -136,6 +136,14 @@ namespace Tanzu.Toolkit.ViewModels
             AppName = _projectService.ProjectName;
             _projectName = _projectService.ProjectName;
             Expanded = false;
+
+            OnClosed = () =>
+            {
+                if (DeploymentInProgress) // don't open tool window if modal was closed via "X" button
+                {
+                    DisplayDeploymentOutput();
+                }
+            };
         }
 
         public string AppName
@@ -545,6 +553,7 @@ namespace Tanzu.Toolkit.ViewModels
             }
         }
 
+        public Action OnClosed { get; set; }
 
         public bool CanDeployApp(object arg)
         {

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -57,7 +57,7 @@ namespace Tanzu.Toolkit.ViewModels
         private string _directoryPathLabel;
         private string _directoryPath;
         private string _targetName;
-        private bool _isLoggedIn;
+        private bool _isLoggedIn = false;
         private string _selectedStack;
         private string _serviceNotRecognizedWarningMessage;
         private ObservableCollection<string> _selectedBuildpacks;

--- a/src/ViewModels/src/DeploymentDialog/IDeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/IDeploymentDialogViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 
 namespace Tanzu.Toolkit.ViewModels
@@ -14,6 +15,7 @@ namespace Tanzu.Toolkit.ViewModels
         bool DeploymentInProgress { get; }
         bool ConfigureForRemoteDebugging { get; set; }
         bool IsLoggedIn { get; set; }
+        Action OnClosed { get; set; }
 
         bool CanDeployApp(object arg);
         bool CanToggleAdvancedOptions(object arg);

--- a/src/ViewModels/src/DeploymentDialog/IDeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/IDeploymentDialogViewModel.cs
@@ -12,7 +12,6 @@ namespace Tanzu.Toolkit.ViewModels
         ObservableCollection<string> SelectedBuildpacks { get; set; }
         ObservableCollection<string> SelectedServices { get; set; }
         bool DeploymentInProgress { get; }
-        IView OutputView { get; }
         bool ConfigureForRemoteDebugging { get; set; }
         bool IsLoggedIn { get; set; }
 
@@ -33,5 +32,6 @@ namespace Tanzu.Toolkit.ViewModels
         void ClearSelectedServices(object arg = null);
         void ClearSelectedManifest(object arg = null);
         void ClearSelectedDeploymentDirectory(object arg = null);
+        void DisplayDeploymentOutput();
     }
 }

--- a/src/ViewModels/src/DeploymentDialog/IDeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/IDeploymentDialogViewModel.cs
@@ -15,6 +15,7 @@ namespace Tanzu.Toolkit.ViewModels
         bool DeploymentInProgress { get; }
         bool ConfigureForRemoteDebugging { get; set; }
         bool IsLoggedIn { get; set; }
+        Action OnRendered { get; set; }
         Action OnClosed { get; set; }
 
         bool CanDeployApp(object arg);

--- a/src/ViewModels/src/IView.cs
+++ b/src/ViewModels/src/IView.cs
@@ -6,7 +6,5 @@ namespace Tanzu.Toolkit.ViewModels
     {
         IViewModel ViewModel { get; }
         Action DisplayView { get; set; }
-
-        void Show();
     }
 }

--- a/src/ViewModels/src/Output/OutputViewModel.cs
+++ b/src/ViewModels/src/Output/OutputViewModel.cs
@@ -111,7 +111,7 @@ namespace Tanzu.Toolkit.ViewModels
             _view = outputView;
             var recentLogsTask = CfClient.GetRecentLogsAsync(cfApp);
             OutputIsAppLogs = true;
-            outputView.Show();
+            outputView.DisplayView();
             AppendLine($"\n*** Fetching recent app logs for \"{cfApp.AppName}\" in org \"{cfApp.ParentSpace.ParentOrg.OrgName}\" and space {cfApp.ParentSpace.SpaceName}... ***");
 
             var recentLogsResult = await recentLogsTask;

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -408,13 +408,8 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             if (view.ViewModel is IDeploymentDialogViewModel vm)
             {
                 vm.ConfigureForRemoteDebugging = true;
+                vm.OnClosed += () => Close();
                 view.DisplayView();
-            }
-
-            if (deploymentViewModel.DeploymentInProgress)
-            {
-                Close();
-                deploymentViewModel.DisplayDeploymentOutput();
             }
         }
 

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -408,6 +408,7 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             if (view.ViewModel is IDeploymentDialogViewModel vm)
             {
                 vm.ConfigureForRemoteDebugging = true;
+                view.DisplayView();
             }
 
             if (deploymentViewModel.DeploymentInProgress)

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -403,12 +403,12 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             projSvc.PathToProjectDirectory = _pathToProjectRootDir;
             projSvc.TargetFrameworkMoniker = _targetFrameworkMoniker;
 
-            var tasExplorer = Services.GetRequiredService<ITasExplorerViewModel>();
-            var deploymentViewModel = Services.GetRequiredService<IDeploymentDialogViewModel>();
-            deploymentViewModel.IsLoggedIn = tasExplorer.TasConnection != null;
-            deploymentViewModel.Expanded = false;
-            deploymentViewModel.ConfigureForRemoteDebugging = true;
-            DialogService.ShowModal(nameof(DeploymentDialogViewModel));
+            var view = ViewLocatorService.GetViewByViewModelName(nameof(DeploymentDialogViewModel)) as IView;
+            var deploymentViewModel = view.ViewModel as IDeploymentDialogViewModel;
+            if (view.ViewModel is IDeploymentDialogViewModel vm)
+            {
+                vm.ConfigureForRemoteDebugging = true;
+            }
 
             if (deploymentViewModel.DeploymentInProgress)
             {

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -413,7 +413,7 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             if (deploymentViewModel.DeploymentInProgress)
             {
                 Close();
-                deploymentViewModel.OutputView.Show();
+                deploymentViewModel.OutputView.DisplayView();
             }
         }
 

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -414,7 +414,7 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             if (deploymentViewModel.DeploymentInProgress)
             {
                 Close();
-                deploymentViewModel.OutputView.DisplayView();
+                deploymentViewModel.DisplayDeploymentOutput();
             }
         }
 

--- a/src/ViewModels/src/TasExplorer/TasExplorerViewModel.cs
+++ b/src/ViewModels/src/TasExplorer/TasExplorerViewModel.cs
@@ -295,7 +295,7 @@ namespace Tanzu.Toolkit.ViewModels
                     var outputView = ViewLocatorService.GetViewByViewModelName(nameof(OutputViewModel), $"\"{cfApp.AppName}\" Logs") as IView;
                     var outputViewModel = outputView?.ViewModel as IOutputViewModel;
 
-                    outputView.Show();
+                    outputView.DisplayView();
 
                     outputViewModel.AppendLine(recentLogsResult.Content);
                 }

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -40,11 +40,6 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             _fakeSelectedServices = new ObservableCollection<string> { _fakeServiceName1, _fakeServiceName2, _fakeServiceName3 };
             var fakeTasConnection = new FakeCfInstanceViewModel(_fakeCfInstance, Services);
 
-            // * return fake view/viewmodel for output window
-            MockViewLocatorService.Setup(mock =>
-                mock.GetViewByViewModelName(nameof(OutputViewModel), It.IsAny<string>()))
-                    .Returns(new FakeOutputView());
-
             MockFileService.Setup(m => m.FileExists(_fakeManifestPath)).Returns(true);
             MockFileService.Setup(m => m.DirectoryExists(_fakeProjectPath)).Returns(true);
             MockFileService.Setup(m => m.DirContainsFiles(_fakeProjectPath)).Returns(true);
@@ -52,6 +47,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             MockProjectService.SetupGet(m => m.ProjectName).Returns(_fakeProjName);
             MockProjectService.SetupGet(m => m.PathToProjectDirectory).Returns(_fakeProjectPath);
             MockProjectService.SetupGet(m => m.TargetFrameworkMoniker).Returns(_fakeTargetFrameworkMoniker);
+            MockViewLocatorService.Setup(m => m.GetViewByViewModelName(nameof(OutputViewModel), It.IsAny<string>())).Returns(_fakeOutputView);
 
             _sut = new DeploymentDialogViewModel(Services)
             {
@@ -363,34 +359,6 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
             MockDialogService.Verify(mock => mock.CloseDialog(dw, true), Times.Once);
             MockThreadingService.Verify(mock => mock.StartBackgroundTask(_sut.StartDeployment), Times.Once);
-        }
-
-        [TestMethod]
-        [TestCategory("DeployApp")]
-        public void DeployApp_CreatesNewOutputView_WhenCanDeployAppIsTrue()
-        {
-            var dw = new object();
-
-            _sut.AppName = _fakeAppName;
-            _sut.SelectedOrg = _fakeOrg;
-            _sut.SelectedSpace = _fakeSpace;
-            _sut.IsLoggedIn = true;
-            var initialView = _sut.OutputView;
-            var initialViewModel = _sut._outputViewModel;
-
-            // sanity check: ctor should've created a view already
-            MockViewLocatorService.Verify(mock =>
-                mock.GetViewByViewModelName(nameof(OutputViewModel), It.Is<string>(s => s.Contains("Tanzu Push Output"))),
-                Times.Once);
-
-            Assert.IsTrue(_sut.CanDeployApp(null));
-
-            _sut.DeployApp(dw);
-
-            // ensure new view was requested
-            MockViewLocatorService.Verify(mock =>
-                mock.GetViewByViewModelName(nameof(OutputViewModel), It.Is<string>(s => s.Contains("Tanzu Push Output"))),
-                Times.Exactly(2));
         }
 
         [TestMethod]

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -216,6 +216,20 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
         [TestMethod]
         [TestCategory("ctor")]
+        [TestCategory("OnClosed")]
+        public void Constructor_SetsOnClosedAction_ToDisplayDeploymentOutputIfDeploymentInProgress()
+        {
+            Assert.AreEqual(_fakeOutputView, _sut._outputView);
+            Assert.IsFalse(_fakeOutputView.ShowMethodWasCalled);
+            _sut.DeploymentInProgress = true; // fake so action will try to display output view
+            
+            _sut.OnClosed();
+            
+            Assert.IsTrue(_fakeOutputView.ShowMethodWasCalled);
+        }
+
+        [TestMethod]
+        [TestCategory("ctor")]
         [TestCategory("ManifestModel")]
         public void Constructor_SetsManifestModel_ToNewAppManifest_WhenNoDefaultManifestExistsAtAnExpectedPath()
         {

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -216,15 +216,28 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
         [TestMethod]
         [TestCategory("ctor")]
+        [TestCategory("OnRendered")]
+        public void Constructor_SetsOnRenderedAction_ToSetManifestPathIfDefaultExists()
+        {
+            MockFileService.Setup(m => m.FileExists(It.Is<string>(s => s.Contains("manifest.yaml")))).Returns(true);
+            Assert.IsNull(_sut.ManifestPath);
+
+            _sut.OnRendered();
+
+            Assert.IsNotNull(_sut.ManifestPath);
+        }
+
+        [TestMethod]
+        [TestCategory("ctor")]
         [TestCategory("OnClosed")]
         public void Constructor_SetsOnClosedAction_ToDisplayDeploymentOutputIfDeploymentInProgress()
         {
             Assert.AreEqual(_fakeOutputView, _sut._outputView);
             Assert.IsFalse(_fakeOutputView.ShowMethodWasCalled);
             _sut.DeploymentInProgress = true; // fake so action will try to display output view
-            
+
             _sut.OnClosed();
-            
+
             Assert.IsTrue(_fakeOutputView.ShowMethodWasCalled);
         }
 
@@ -285,6 +298,7 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             MockSerializationService.Setup(m => m.ParseCfAppManifest(fakeManifestContent)).Returns(_fakeManifestModel);
 
             _sut = new DeploymentDialogViewModel(Services);
+            _sut.OnRendered(); // perform steps taken after rendering (i.e. setting values from manifest)
 
             Assert.IsNotNull(_sut.ManifestModel.Applications[0].Path); // ensure path value specified
             Assert.AreEqual(expectedPathValue, _sut.ManifestModel.Applications[0].Path);

--- a/src/ViewModels/test/ViewModelTestSupport.cs
+++ b/src/ViewModels/test/ViewModelTestSupport.cs
@@ -107,21 +107,21 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
         internal class FakeOutputView : IView
         {
+            private Action _displayView;
             public IViewModel ViewModel { get; set; }
 
             public bool ShowMethodWasCalled { get; private set; }
 
-            public Action DisplayView { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public Action DisplayView
+            {
+                get => _displayView ?? (() => { ShowMethodWasCalled = true; });
+                set => _displayView = value;
+            }
 
             public FakeOutputView()
             {
                 ViewModel = new FakeOutputViewModel();
                 ShowMethodWasCalled = false;
-            }
-
-            public void Show()
-            {
-                ShowMethodWasCalled = true;
             }
         }
 

--- a/src/ViewModels/test/ViewModelTestSupport.cs
+++ b/src/ViewModels/test/ViewModelTestSupport.cs
@@ -105,6 +105,9 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             new CloudFoundryApp("fakeApp5", "fake-app-guid-5", _fakeCfSpace, "junk state"),
         };
 
+        internal static FakeOutputView _fakeOutputView = new FakeOutputView();
+        internal static FakeOutputViewModel _fakeOutputViewModel = new FakeOutputViewModel();
+
         internal class FakeOutputView : IView
         {
             private Action _displayView;

--- a/src/VisualStudioExtension/src/Commands/PushToCloudFoundryCommand.cs
+++ b/src/VisualStudioExtension/src/Commands/PushToCloudFoundryCommand.cs
@@ -141,12 +141,12 @@ namespace Tanzu.Toolkit.VisualStudio.Commands
 
                             var view = _services.GetRequiredService<IDeploymentDialogView>() as IView;
                             var deploymentViewModel = view.ViewModel as IDeploymentDialogViewModel;
-                            view.Show();
+                            view.DisplayView();
 
                             // * Actions to take after modal closes:
                             if (deploymentViewModel.DeploymentInProgress) // don't open tool window if modal was closed via "X" button
                             {
-                                deploymentViewModel.OutputView.Show();
+                                deploymentViewModel.OutputView.DisplayView();
                             }
                         }
                     }

--- a/src/VisualStudioExtension/src/Commands/PushToCloudFoundryCommand.cs
+++ b/src/VisualStudioExtension/src/Commands/PushToCloudFoundryCommand.cs
@@ -139,13 +139,9 @@ namespace Tanzu.Toolkit.VisualStudio.Commands
                             projSvc.PathToProjectDirectory = projectDirectory;
                             projSvc.TargetFrameworkMoniker = tfm;
 
-                            var tasExplorer = _services.GetRequiredService<ITasExplorerViewModel>();
-                            var deploymentViewModel = _services.GetRequiredService<IDeploymentDialogViewModel>();
-                            deploymentViewModel.IsLoggedIn = tasExplorer.TasConnection != null;
-                            deploymentViewModel.Expanded = false;
-
-                            var deploymentWindow = _services.GetRequiredService<IDeploymentDialogView>() as Microsoft.VisualStudio.PlatformUI.DialogWindow;
-                            deploymentWindow?.ShowModal();
+                            var view = _services.GetRequiredService<IDeploymentDialogView>() as IView;
+                            var deploymentViewModel = view.ViewModel as IDeploymentDialogViewModel;
+                            view.Show();
 
                             // * Actions to take after modal closes:
                             if (deploymentViewModel.DeploymentInProgress) // don't open tool window if modal was closed via "X" button

--- a/src/VisualStudioExtension/src/Commands/PushToCloudFoundryCommand.cs
+++ b/src/VisualStudioExtension/src/Commands/PushToCloudFoundryCommand.cs
@@ -142,12 +142,6 @@ namespace Tanzu.Toolkit.VisualStudio.Commands
                             var view = _services.GetRequiredService<IDeploymentDialogView>() as IView;
                             var deploymentViewModel = view.ViewModel as IDeploymentDialogViewModel;
                             view.DisplayView();
-
-                            // * Actions to take after modal closes:
-                            if (deploymentViewModel.DeploymentInProgress) // don't open tool window if modal was closed via "X" button
-                            {
-                                deploymentViewModel.DisplayDeploymentOutput();
-                            }
                         }
                     }
                 }

--- a/src/VisualStudioExtension/src/Commands/PushToCloudFoundryCommand.cs
+++ b/src/VisualStudioExtension/src/Commands/PushToCloudFoundryCommand.cs
@@ -146,7 +146,7 @@ namespace Tanzu.Toolkit.VisualStudio.Commands
                             // * Actions to take after modal closes:
                             if (deploymentViewModel.DeploymentInProgress) // don't open tool window if modal was closed via "X" button
                             {
-                                deploymentViewModel.OutputView.DisplayView();
+                                deploymentViewModel.DisplayDeploymentOutput();
                             }
                         }
                     }

--- a/src/VisualStudioExtension/src/Commands/PushToCloudFoundryCommand.cs
+++ b/src/VisualStudioExtension/src/Commands/PushToCloudFoundryCommand.cs
@@ -160,7 +160,8 @@ namespace Tanzu.Toolkit.VisualStudio.Commands
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 _logger?.Error("{ClassName} caught exception in {MethodName}: {PushException}", nameof(PushToCloudFoundryCommand), nameof(Execute), ex);
-                var msg = ex.Message + Environment.NewLine + Environment.NewLine +
+                var msg = $"Internal error: \"{ex.Message}\"" 
+                    + Environment.NewLine + Environment.NewLine +
                     "If this issue persists, please contact tas-vs-extension@vmware.com";
                 _dialogService.DisplayErrorDialog("Unable to push to Tanzu Application Service", msg);
             }

--- a/src/VisualStudioExtension/src/Services/IToolWindowService.cs
+++ b/src/VisualStudioExtension/src/Services/IToolWindowService.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using Tanzu.Toolkit.ViewModels;
 
 namespace Tanzu.Toolkit.VisualStudio.Services
 {
     public interface IToolWindowService
     {
-        object CreateToolWindowForView(Type viewType, string caption);
+        IView CreateToolWindowForView(Type viewType, string caption);
     }
 }

--- a/src/VisualStudioExtension/src/Services/VsToolWindowService.cs
+++ b/src/VisualStudioExtension/src/Services/VsToolWindowService.cs
@@ -21,7 +21,7 @@ namespace Tanzu.Toolkit.VisualStudio.Services
             _logger = loggingService.Logger;
         }
 
-        public object CreateToolWindowForView(Type viewType, string caption)
+        public IView CreateToolWindowForView(Type viewType, string caption)
         {
             IView view = null;
             Type toolWindowType = null;

--- a/src/VisualStudioExtension/src/Services/VsViewLocatorService.cs
+++ b/src/VisualStudioExtension/src/Services/VsViewLocatorService.cs
@@ -66,23 +66,8 @@ namespace Tanzu.Toolkit.VisualStudio.Services
 
         internal bool ViewShownAsModal(Type type)
         {
-            return type == typeof(ILoginView)
-                || type == typeof(IDeploymentDialogView)
-                || type == typeof(IAppDeletionConfirmationView)
-                || type == typeof(IRemoteDebugView);
-
-            /** ^ this solution is admittedly not ideal because it will require updating when adding/changing modals.
-             * A preferred solution is shown below, but for some unknown reason the reference to AbstractModel prompts
-             * an error when running tests *specifically in VS 2019* (tests pass in VS 2022):
-             *      System.IO.FileNotFoundException: Could not load file or assembly 'PresentationFramework, 
-             *      Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the 
-             *      file specified.
-             * This error is bizarre because the PresentationFramework assembly (v4.0.0.0)  is definitely present
-             * 
-             *      var expectedImplementationType = Type.GetType(type.Namespace + "." + type.Name.Substring(1));
-             *      return expectedImplementationType != null && expectedImplementationType.IsSubclassOf(typeof(AbstractModal));
-             */
-
+            var expectedImplementationType = Type.GetType(type.Namespace + "." + type.Name.Substring(1));
+            return expectedImplementationType != null && expectedImplementationType.IsSubclassOf(typeof(AbstractModal));
         }
 
         internal bool ViewShownAsToolWindow(Type type)

--- a/src/VisualStudioExtension/src/Services/VsViewLocatorService.cs
+++ b/src/VisualStudioExtension/src/Services/VsViewLocatorService.cs
@@ -1,7 +1,9 @@
 ﻿using Serilog;
 using System;
+using System.Windows;
 using Tanzu.Toolkit.Services.Logging;
 using Tanzu.Toolkit.Services.ViewLocator;
+using Tanzu.Toolkit.ViewModels;
 using Tanzu.Toolkit.VisualStudio.Views;
 
 namespace Tanzu.Toolkit.VisualStudio.Services
@@ -25,7 +27,7 @@ namespace Tanzu.Toolkit.VisualStudio.Services
 
         public virtual object GetViewByViewModelName(string viewModelName, object parameter = null)
         {
-            object view = null;
+            IView view = null;
             try
             {
                 var viewTypeName = GetViewName(viewModelName);
@@ -39,7 +41,10 @@ namespace Tanzu.Toolkit.VisualStudio.Services
                 {
                     try
                     {
-                        view = ServiceProvider.GetService(type);
+                        var instance = ServiceProvider.GetService(type);
+                        view = instance as IView;
+                        var dialogWindow = Window.GetWindow((DependencyObject)view) as Microsoft.VisualStudio.PlatformUI.DialogWindow;
+                        view.DisplayView = () => dialogWindow.ShowModal(); 
                     }
                     catch (Exception ex)
                     {

--- a/src/VisualStudioExtension/src/Services/VsViewLocatorService.cs
+++ b/src/VisualStudioExtension/src/Services/VsViewLocatorService.cs
@@ -66,8 +66,23 @@ namespace Tanzu.Toolkit.VisualStudio.Services
 
         internal bool ViewShownAsModal(Type type)
         {
-            var expectedImplementationType = Type.GetType(type.Namespace + "." + type.Name.Substring(1));
-            return expectedImplementationType != null && expectedImplementationType.IsSubclassOf(typeof(AbstractModal));
+            return type == typeof(ILoginView)
+                || type == typeof(IDeploymentDialogView)
+                || type == typeof(IAppDeletionConfirmationView)
+                || type == typeof(IRemoteDebugView);
+
+            /** ^ this solution is admittedly not ideal because it will require updating when adding/changing modals.
+             * A preferred solution is shown below, but for some unknown reason the reference to AbstractModel prompts
+             * an error when running tests *specifically in VS 2019* (tests pass in VS 2022):
+             *      System.IO.FileNotFoundException: Could not load file or assembly 'PresentationFramework, 
+             *      Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the 
+             *      file specified.
+             * This error is bizarre because the PresentationFramework assembly (v4.0.0.0)  is definitely present
+             * 
+             *      var expectedImplementationType = Type.GetType(type.Namespace + "." + type.Name.Substring(1));
+             *      return expectedImplementationType != null && expectedImplementationType.IsSubclassOf(typeof(AbstractModal));
+             */
+
         }
 
         internal bool ViewShownAsToolWindow(Type type)

--- a/src/VisualStudioExtension/src/Services/VsViewLocatorService.cs
+++ b/src/VisualStudioExtension/src/Services/VsViewLocatorService.cs
@@ -41,14 +41,11 @@ namespace Tanzu.Toolkit.VisualStudio.Services
                 {
                     try
                     {
-                        var instance = ServiceProvider.GetService(type);
-                        view = instance as IView;
-                        var dialogWindow = Window.GetWindow((DependencyObject)view) as Microsoft.VisualStudio.PlatformUI.DialogWindow;
-                        view.DisplayView = () => dialogWindow.ShowModal(); 
+                        view = ServiceProvider.GetService(type) as IView;
                     }
                     catch (Exception ex)
                     {
-                        _logger?.Error("Caught exception in {ClassName}.{MethodName} thrown because of an unattainable service: {ServiceException}", nameof(VsViewLocatorService), nameof(GetViewByViewModelName), ex);
+                        _logger?.Error("Caught exception in {ClassName}.{MethodName}({ViewModelName}); either the service was unattainable or could not be cast as {CastType}: {ServiceException}", nameof(VsViewLocatorService), nameof(GetViewByViewModelName), viewModelName, nameof(IView), ex);
                     }
                 }
 

--- a/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
+++ b/src/VisualStudioExtension/src/Tanzu.Toolkit.VisualStudioExtension.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Commands\RequestFeedbackCommand.cs" />
     <Compile Include="Commands\RemoteDebugCommand.cs" />
     <Compile Include="Services\ProjectService.cs" />
+    <Compile Include="Views\AbstractModal.cs" />
     <Compile Include="Views\Converters\InverseBoolConverter.cs" />
     <Compile Include="Views\Converters\NullVisibilityConverter.cs" />
     <Compile Include="Views\Converters\IntToBoolConverter.cs" />

--- a/src/VisualStudioExtension/src/TanzuToolkitForVisualStudioPackage.cs
+++ b/src/VisualStudioExtension/src/TanzuToolkitForVisualStudioPackage.cs
@@ -163,7 +163,7 @@ namespace Tanzu.Toolkit.VisualStudio
             services.AddTransient<IOutputViewModel, OutputViewModel>();
             services.AddSingleton<ITasExplorerViewModel, TasExplorerViewModel>();
             services.AddSingleton<ILoginViewModel, LoginViewModel>();
-            services.AddSingleton<IDeploymentDialogViewModel, DeploymentDialogViewModel>();
+            services.AddTransient<IDeploymentDialogViewModel, DeploymentDialogViewModel>();
             services.AddTransient<IRemoteDebugViewModel, RemoteDebugViewModel>();
             services.AddTransient<ILoginViewModel, LoginViewModel>();
             services.AddSingleton<IAppDeletionConfirmationViewModel, AppDeletionConfirmationViewModel>();

--- a/src/VisualStudioExtension/src/Views/AbstractModal.cs
+++ b/src/VisualStudioExtension/src/Views/AbstractModal.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.PlatformUI;
 using System;
+using System.Windows.Input;
 using Tanzu.Toolkit.ViewModels;
 
 namespace Tanzu.Toolkit.VisualStudio.Views
@@ -24,5 +25,13 @@ namespace Tanzu.Toolkit.VisualStudio.Views
         }
 
         public IViewModel ViewModel { get => (IViewModel)DataContext; }
+
+        public void Window_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.LeftButton == MouseButtonState.Pressed)
+            {
+                DragMove();
+            }
+        }
     }
 }

--- a/src/VisualStudioExtension/src/Views/AbstractModal.cs
+++ b/src/VisualStudioExtension/src/Views/AbstractModal.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.VisualStudio.PlatformUI;
+using System;
+using Tanzu.Toolkit.ViewModels;
+
+namespace Tanzu.Toolkit.VisualStudio.Views
+{
+    public class AbstractModal : DialogWindow, IView
+    {
+        private Action _displayView;
+
+        public Action DisplayView
+        {
+            get
+            {
+                if (_displayView == null)
+                {
+                    _displayView = () => ShowModal();
+                }
+
+                return _displayView;
+            }
+
+            set => _displayView = value;
+        }
+
+        public IViewModel ViewModel { get => (IViewModel)DataContext; }
+    }
+}

--- a/src/VisualStudioExtension/src/Views/AppDeletionConfirmationView.xaml
+++ b/src/VisualStudioExtension/src/Views/AppDeletionConfirmationView.xaml
@@ -1,4 +1,5 @@
-﻿<platform:DialogWindow x:Class="Tanzu.Toolkit.VisualStudio.Views.AppDeletionConfirmationView"
+﻿<local:AbstractModal
+    x:Class="Tanzu.Toolkit.VisualStudio.Views.AppDeletionConfirmationView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -8,7 +9,7 @@
              xmlns:toolkit="clr-namespace:Community.VisualStudio.Toolkit;assembly=Community.VisualStudio.Toolkit"
              toolkit:Themes.UseVsTheme="True"
              mc:Ignorable="d"
-             Name ="AppDeletionConfirmationViewElement"
+             x:Name ="AppDeletionConfirmationViewElement"
              Title="Confirm App Deletion"
              MinHeight="200"
              MinWidth="300"
@@ -83,4 +84,4 @@
         </Grid>
     </DockPanel>
 
-</platform:DialogWindow>
+</local:AbstractModal>

--- a/src/VisualStudioExtension/src/Views/AppDeletionConfirmationView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/AppDeletionConfirmationView.xaml.cs
@@ -28,13 +28,5 @@ namespace Tanzu.Toolkit.VisualStudio.Views
         {
             Close();
         }
-
-        private void Window_MouseDown(object sender, MouseButtonEventArgs e)
-        {
-            if (e.LeftButton == MouseButtonState.Pressed)
-            {
-                DragMove();
-            }
-        }
     }
 }

--- a/src/VisualStudioExtension/src/Views/AppDeletionConfirmationView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/AppDeletionConfirmationView.xaml.cs
@@ -9,18 +9,13 @@ namespace Tanzu.Toolkit.VisualStudio.Views
     /// </summary>
     public partial class AppDeletionConfirmationView : AbstractModal, IAppDeletionConfirmationView
     {
-        public IAppDeletionConfirmationViewModel _confirmDeleteViewModel;
-
         public ICommand DeleteAppCommand { get; }
 
         public AppDeletionConfirmationView(IAppDeletionConfirmationViewModel viewModel)
         {
             DeleteAppCommand = new AsyncDelegatingCommand(viewModel.DeleteApp, viewModel.CanDeleteApp);
             DataContext = viewModel;
-            _confirmDeleteViewModel = viewModel;
-
             MouseDown += Window_MouseDown;
-
             InitializeComponent();
         }
 

--- a/src/VisualStudioExtension/src/Views/AppDeletionConfirmationView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/AppDeletionConfirmationView.xaml.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.VisualStudio.PlatformUI;
-using System;
-using System.Windows.Input;
-using Tanzu.Toolkit.ViewModels;
+﻿using System.Windows.Input;
 using Tanzu.Toolkit.ViewModels.AppDeletionConfirmation;
 using Tanzu.Toolkit.VisualStudio.Views.Commands;
 
@@ -10,20 +7,14 @@ namespace Tanzu.Toolkit.VisualStudio.Views
     /// <summary>
     /// Interaction logic for ConfirmationDeleteView.xaml
     /// </summary>
-    public partial class AppDeletionConfirmationView : DialogWindow, IAppDeletionConfirmationView, IView
+    public partial class AppDeletionConfirmationView : AbstractModal, IAppDeletionConfirmationView
     {
         public IAppDeletionConfirmationViewModel _confirmDeleteViewModel;
-        private readonly IAppDeletionConfirmationViewModel _viewModel;
 
         public ICommand DeleteAppCommand { get; }
 
-        public IViewModel ViewModel => (IViewModel)_viewModel;
-
-        public Action DisplayView { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
         public AppDeletionConfirmationView(IAppDeletionConfirmationViewModel viewModel)
         {
-            _viewModel = viewModel;
             DeleteAppCommand = new AsyncDelegatingCommand(viewModel.DeleteApp, viewModel.CanDeleteApp);
             DataContext = viewModel;
             _confirmDeleteViewModel = viewModel;

--- a/src/VisualStudioExtension/src/Views/AppDeletionConfirmationView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/AppDeletionConfirmationView.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.PlatformUI;
+using System;
 using System.Windows.Input;
+using Tanzu.Toolkit.ViewModels;
 using Tanzu.Toolkit.ViewModels.AppDeletionConfirmation;
 using Tanzu.Toolkit.VisualStudio.Views.Commands;
 
@@ -8,10 +10,14 @@ namespace Tanzu.Toolkit.VisualStudio.Views
     /// <summary>
     /// Interaction logic for ConfirmationDeleteView.xaml
     /// </summary>
-    public partial class AppDeletionConfirmationView : DialogWindow, IAppDeletionConfirmationView
+    public partial class AppDeletionConfirmationView : DialogWindow, IAppDeletionConfirmationView, IView
     {
         public IAppDeletionConfirmationViewModel _confirmDeleteViewModel;
         public ICommand DeleteAppCommand { get; }
+
+        public IViewModel ViewModel => throw new NotImplementedException();
+
+        public Action DisplayView { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         public AppDeletionConfirmationView(IAppDeletionConfirmationViewModel viewModel)
         {

--- a/src/VisualStudioExtension/src/Views/AppDeletionConfirmationView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/AppDeletionConfirmationView.xaml.cs
@@ -13,14 +13,17 @@ namespace Tanzu.Toolkit.VisualStudio.Views
     public partial class AppDeletionConfirmationView : DialogWindow, IAppDeletionConfirmationView, IView
     {
         public IAppDeletionConfirmationViewModel _confirmDeleteViewModel;
+        private readonly IAppDeletionConfirmationViewModel _viewModel;
+
         public ICommand DeleteAppCommand { get; }
 
-        public IViewModel ViewModel => throw new NotImplementedException();
+        public IViewModel ViewModel => (IViewModel)_viewModel;
 
         public Action DisplayView { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         public AppDeletionConfirmationView(IAppDeletionConfirmationViewModel viewModel)
         {
+            _viewModel = viewModel;
             DeleteAppCommand = new AsyncDelegatingCommand(viewModel.DeleteApp, viewModel.CanDeleteApp);
             DataContext = viewModel;
             _confirmDeleteViewModel = viewModel;

--- a/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml
+++ b/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml
@@ -1,9 +1,9 @@
-﻿<ui:DialogWindow
+﻿<local:AbstractModal
     x:Class="Tanzu.Toolkit.VisualStudio.Views.DeploymentDialogView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
-    Name="DeploymentDialogViewElement"
+    x:Name="DeploymentDialogViewElement"
     Title="Push to Tanzu Application Service"
     Icon="Resources/tas_16px.png"
     BorderBrush="Gray"
@@ -776,4 +776,4 @@
             </StackPanel>
         </Grid>
     </DockPanel>
-</ui:DialogWindow>
+</local:AbstractModal>

--- a/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
@@ -48,6 +48,12 @@ namespace Tanzu.Toolkit.VisualStudio.Views
             MouseDown += Window_MouseDown;
         }
 
+        protected override void OnContentRendered(EventArgs e)
+        {
+            _viewModel.OnRendered();
+            base.OnContentRendered(e);
+        }
+
         protected override void OnClosed(EventArgs e)
         {
             _viewModel.OnClosed();

--- a/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.VisualStudio.PlatformUI;
-using System;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -13,10 +11,8 @@ namespace Tanzu.Toolkit.VisualStudio.Views
     /// <summary>
     /// Interaction logic for DeploymentDialogView.xaml.
     /// </summary>
-    public partial class DeploymentDialogView : DialogWindow, IDeploymentDialogView, IView
+    public partial class DeploymentDialogView : AbstractModal, IDeploymentDialogView
     {
-        private readonly IDeploymentDialogViewModel _viewModel;
-        private Action _displayView;
         public ICommand UploadAppCommand { get; }
         public ICommand OpenLoginDialogCommand { get; }
         public ICommand ToggleAdvancedOptionsCommand { get; }
@@ -28,24 +24,8 @@ namespace Tanzu.Toolkit.VisualStudio.Views
 
         public Brush HyperlinkBrush { get { return (Brush)GetValue(_hyperlinkBrushProperty); } set { SetValue(_hyperlinkBrushProperty, value); } }
 
-        public IViewModel ViewModel { get => (IViewModel)_viewModel; }
-
-        public Action DisplayView
-        {
-            get
-            {
-                if (_displayView == null)
-                {
-                    _displayView = () => ShowModal();
-                }
-
-                return _displayView;
-            }
-
-            set => _displayView = value;
-        }
-
         public static readonly DependencyProperty _hyperlinkBrushProperty = DependencyProperty.Register("HyperlinkBrush", typeof(Brush), typeof(DeploymentDialogView), new PropertyMetadata(default(Brush)));
+        private readonly IDeploymentDialogViewModel _viewModel;
 
         public DeploymentDialogView()
         {

--- a/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -45,6 +46,12 @@ namespace Tanzu.Toolkit.VisualStudio.Views
             InitializeComponent();
 
             MouseDown += Window_MouseDown;
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _viewModel.OnClosed();
+            base.OnClosed(e);
         }
 
         private void CfOrgOptions_ComboBox_DropDownClosed(object sender, System.EventArgs e)

--- a/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.PlatformUI;
+using System;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
@@ -12,9 +13,10 @@ namespace Tanzu.Toolkit.VisualStudio.Views
     /// <summary>
     /// Interaction logic for DeploymentDialogView.xaml.
     /// </summary>
-    public partial class DeploymentDialogView : DialogWindow, IDeploymentDialogView
+    public partial class DeploymentDialogView : DialogWindow, IDeploymentDialogView, IView
     {
         private readonly IDeploymentDialogViewModel _viewModel;
+        private Action _displayView;
         public ICommand UploadAppCommand { get; }
         public ICommand OpenLoginDialogCommand { get; }
         public ICommand ToggleAdvancedOptionsCommand { get; }
@@ -25,6 +27,23 @@ namespace Tanzu.Toolkit.VisualStudio.Views
         public string PlaceholderText { get; set; }
 
         public Brush HyperlinkBrush { get { return (Brush)GetValue(_hyperlinkBrushProperty); } set { SetValue(_hyperlinkBrushProperty, value); } }
+
+        public IViewModel ViewModel { get => (IViewModel)_viewModel; }
+
+        public Action DisplayView
+        {
+            get
+            {
+                if (_displayView == null)
+                {
+                    _displayView = () => ShowModal();
+                }
+
+                return _displayView;
+            }
+
+            set => _displayView = value;
+        }
 
         public static readonly DependencyProperty _hyperlinkBrushProperty = DependencyProperty.Register("HyperlinkBrush", typeof(Brush), typeof(DeploymentDialogView), new PropertyMetadata(default(Brush)));
 

--- a/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
@@ -27,11 +27,6 @@ namespace Tanzu.Toolkit.VisualStudio.Views
         public static readonly DependencyProperty _hyperlinkBrushProperty = DependencyProperty.Register("HyperlinkBrush", typeof(Brush), typeof(DeploymentDialogView), new PropertyMetadata(default(Brush)));
         private readonly IDeploymentDialogViewModel _viewModel;
 
-        public DeploymentDialogView()
-        {
-            InitializeComponent();
-        }
-
         public DeploymentDialogView(IDeploymentDialogViewModel viewModel, IThemeService themeService)
         {
             _viewModel = viewModel;

--- a/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
@@ -91,15 +91,6 @@ namespace Tanzu.Toolkit.VisualStudio.Views
             Close();
         }
 
-        private void Window_MouseDown(object sender, MouseButtonEventArgs e)
-        {
-            if (e.LeftButton == MouseButtonState.Pressed)
-            {
-                DragMove();
-            }
-
-        }
-
         private void BuildpackItemSelected(object sender, RoutedEventArgs e)
         {
             if (e.Source is System.Windows.Controls.CheckBox cb)

--- a/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
@@ -88,7 +88,7 @@ namespace Tanzu.Toolkit.VisualStudio.Views
 
         private void Close(object sender, RoutedEventArgs e)
         {
-            Hide();
+            Close();
         }
 
         private void Window_MouseDown(object sender, MouseButtonEventArgs e)

--- a/src/VisualStudioExtension/src/Views/IOutputView.cs
+++ b/src/VisualStudioExtension/src/Views/IOutputView.cs
@@ -3,6 +3,5 @@
     public interface IOutputView
     {
         void InitializeComponent();
-        void Show();
     }
 }

--- a/src/VisualStudioExtension/src/Views/LoginView.xaml
+++ b/src/VisualStudioExtension/src/Views/LoginView.xaml
@@ -1,9 +1,9 @@
-﻿<ui:DialogWindow 
+﻿<views:AbstractModal
     x:Class="Tanzu.Toolkit.VisualStudio.Views.LoginView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
-    Name ="LoginViewElement"
+    x:Name ="LoginViewElement"
     WindowStartupLocation="CenterScreen"
     WindowStyle="None"
     ResizeMode="NoResize"
@@ -381,4 +381,4 @@
             </Grid>
         </StackPanel>
     </StackPanel>
-</ui:DialogWindow>
+</views:AbstractModal>

--- a/src/VisualStudioExtension/src/Views/LoginView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/LoginView.xaml.cs
@@ -25,11 +25,6 @@ namespace Tanzu.Toolkit.VisualStudio.Views
 
         public static readonly DependencyProperty _hyperlinkBrushProperty = DependencyProperty.Register("HyperlinkBrush", typeof(Brush), typeof(LoginView), new PropertyMetadata(default(Brush)));
 
-        public LoginView()
-        {
-            InitializeComponent();
-        }
-
         public LoginView(ILoginViewModel viewModel, IThemeService themeService)
         {
             bool alwaysTrue(object arg) { return true; }

--- a/src/VisualStudioExtension/src/Views/LoginView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/LoginView.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.PlatformUI;
+using System;
 using System.Diagnostics;
 using System.Security;
 using System.Windows;
@@ -13,9 +14,10 @@ namespace Tanzu.Toolkit.VisualStudio.Views
     /// <summary>
     /// Interaction logic for LoginView.xaml.
     /// </summary>
-    public partial class LoginView : DialogWindow, ILoginView
+    public partial class LoginView : DialogWindow, ILoginView, IView
     {
         private readonly ILoginViewModel _viewModel;
+        private Action _displayView;
         public ICommand AddCloudCommand { get; }
         public ICommand SsoCommand { get; }
         public ICommand IncrementPageCommand { get; }
@@ -23,6 +25,22 @@ namespace Tanzu.Toolkit.VisualStudio.Views
         public ICommand LogInWithPasscodeCommand { get; }
 
         public Brush HyperlinkBrush { get { return (Brush)GetValue(_hyperlinkBrushProperty); } set { SetValue(_hyperlinkBrushProperty, value); } }
+
+        public IViewModel ViewModel => _viewModel;
+        public Action DisplayView
+        {
+            get
+            {
+                if (_displayView == null)
+                {
+                    _displayView = () => ShowModal();
+                }
+
+                return _displayView;
+            }
+
+            set => _displayView = value;
+        }
 
         public static readonly DependencyProperty _hyperlinkBrushProperty = DependencyProperty.Register("HyperlinkBrush", typeof(Brush), typeof(LoginView), new PropertyMetadata(default(Brush)));
 

--- a/src/VisualStudioExtension/src/Views/LoginView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/LoginView.xaml.cs
@@ -74,14 +74,6 @@ namespace Tanzu.Toolkit.VisualStudio.Views
             _viewModel.NavigateToTargetPage();
         }
 
-        private void Window_MouseDown(object sender, MouseButtonEventArgs e)
-        {
-            if (e.LeftButton == MouseButtonState.Pressed)
-            {
-                DragMove();
-            }
-        }
-
         private void TbUrl_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
         {
             _viewModel.TargetApiAddress = tbUrl.Text; // update property *before* focus is lost from text box 

--- a/src/VisualStudioExtension/src/Views/LoginView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/LoginView.xaml.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.VisualStudio.PlatformUI;
-using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Security;
 using System.Windows;
 using System.Windows.Input;
@@ -14,10 +12,9 @@ namespace Tanzu.Toolkit.VisualStudio.Views
     /// <summary>
     /// Interaction logic for LoginView.xaml.
     /// </summary>
-    public partial class LoginView : DialogWindow, ILoginView, IView
+    public partial class LoginView : AbstractModal, ILoginView
     {
         private readonly ILoginViewModel _viewModel;
-        private Action _displayView;
         public ICommand AddCloudCommand { get; }
         public ICommand SsoCommand { get; }
         public ICommand IncrementPageCommand { get; }
@@ -25,22 +22,6 @@ namespace Tanzu.Toolkit.VisualStudio.Views
         public ICommand LogInWithPasscodeCommand { get; }
 
         public Brush HyperlinkBrush { get { return (Brush)GetValue(_hyperlinkBrushProperty); } set { SetValue(_hyperlinkBrushProperty, value); } }
-
-        public IViewModel ViewModel => _viewModel;
-        public Action DisplayView
-        {
-            get
-            {
-                if (_displayView == null)
-                {
-                    _displayView = () => ShowModal();
-                }
-
-                return _displayView;
-            }
-
-            set => _displayView = value;
-        }
 
         public static readonly DependencyProperty _hyperlinkBrushProperty = DependencyProperty.Register("HyperlinkBrush", typeof(Brush), typeof(LoginView), new PropertyMetadata(default(Brush)));
 

--- a/src/VisualStudioExtension/src/Views/OutputView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/OutputView.xaml.cs
@@ -53,11 +53,6 @@ namespace Tanzu.Toolkit.VisualStudio.Views
             autoScrollToggleBtn.IsChecked = true;
         }
 
-        public void Show()
-        {
-            DisplayView?.Invoke();
-        }
-
         /// <summary>
         /// This action starts null; the expectation is that VsToolWindowService will provide 
         /// a method which is able to display the tool window associated with this view.

--- a/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml
+++ b/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml
@@ -1,4 +1,4 @@
-﻿<ui:DialogWindow
+﻿<local:AbstractModal
     x:Class="Tanzu.Toolkit.VisualStudio.RemoteDebugView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -11,7 +11,7 @@
     mc:Ignorable="d"
     d:DesignHeight="450" d:DesignWidth="800"
     Title="Remote Debug"
-    Name="RemoteDebugViewElement"
+    x:Name="RemoteDebugViewElement"
     Icon="Resources/tas_16px.png"
     BorderThickness="1"
     ResizeMode="NoResize"
@@ -154,4 +154,4 @@
                     HorizontalAlignment="Right"/>
         </StackPanel>
     </DockPanel>
-</ui:DialogWindow>
+</local:AbstractModal>

--- a/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml.cs
@@ -40,14 +40,6 @@ namespace Tanzu.Toolkit.VisualStudio
             InitializeComponent();
         }
 
-        private void Window_MouseDown(object sender, MouseButtonEventArgs e)
-        {
-            if (e.LeftButton == MouseButtonState.Pressed)
-            {
-                DragMove();
-            }
-        }
-
         private void Close(object sender, RoutedEventArgs e)
         {
             Hide();

--- a/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml.cs
@@ -39,10 +39,5 @@ namespace Tanzu.Toolkit.VisualStudio
             MouseDown += Window_MouseDown;
             InitializeComponent();
         }
-
-        private void Close(object sender, RoutedEventArgs e)
-        {
-            Hide();
-        }
     }
 }

--- a/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml.cs
@@ -12,7 +12,7 @@ namespace Tanzu.Toolkit.VisualStudio
     /// <summary>
     /// Interaction logic for RemoteDebugView.xaml
     /// </summary>
-    public partial class RemoteDebugView : DialogWindow, IRemoteDebugView
+    public partial class RemoteDebugView : AbstractModal, IRemoteDebugView
     {
         public ICommand CancelCommand { get; }
         public ICommand OpenLoginViewCommand { get; }

--- a/src/VisualStudioExtension/src/Views/TasExplorerView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/TasExplorerView.xaml.cs
@@ -62,11 +62,6 @@ namespace Tanzu.Toolkit.VisualStudio.Views
             InitializeComponent();
         }
 
-        public void Show()
-        {
-            DisplayView?.Invoke();
-        }
-
         private void Disconnect(object sender, RoutedEventArgs e)
         {
             DeleteConnectionCommand.Execute(null);

--- a/src/VisualStudioExtension/test/Tanzu.Toolkit.VisualStudioExtension.Tests.csproj
+++ b/src/VisualStudioExtension/test/Tanzu.Toolkit.VisualStudioExtension.Tests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Services\src\Tanzu.Toolkit.Services.csproj" />
+    <ProjectReference Include="..\..\ViewModels\src\Tanzu.Toolkit.ViewModels.csproj" />
     <ProjectReference Include="..\src\Tanzu.Toolkit.VisualStudioExtension.csproj" />
   </ItemGroup>
 

--- a/src/VisualStudioExtension/test/Tanzu.Toolkit.VisualStudioExtension.Tests.csproj
+++ b/src/VisualStudioExtension/test/Tanzu.Toolkit.VisualStudioExtension.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-
+    <UseWPF>true</UseWPF>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/VisualStudioExtension/test/VsViewLocatorServiceTests.cs
+++ b/src/VisualStudioExtension/test/VsViewLocatorServiceTests.cs
@@ -4,6 +4,7 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using Tanzu.Toolkit.Services.Logging;
+using Tanzu.Toolkit.ViewModels;
 using Tanzu.Toolkit.VisualStudio.Services;
 using Tanzu.Toolkit.VisualStudio.Views;
 
@@ -23,7 +24,7 @@ namespace Tanzu.Toolkit.VisualStudioExtension.Tests
         private readonly string _fakeViewModelName = "MyCoolViewModel";
         private readonly string _fakeViewName = "IMyCoolView";
         private Type _fakeViewType;
-        private readonly object _fakeReturnedView = "Pretend this is a view";
+        private readonly FakeView _fakeReturnedView = new();
 
         [TestInitialize]
         public void TestInit()
@@ -65,7 +66,7 @@ namespace Tanzu.Toolkit.VisualStudioExtension.Tests
         public void GetViewByViewModelName_CreatesToolWindow_AndReturnsView_WhenInterpretedViewTypeIsIOutputView()
         {
             var expectedViewType = typeof(IOutputView);
-            var fakeViewFromToolWindow = new object();
+            var fakeViewFromToolWindow = new FakeView();
             var fakeCaptionParam = "some caption";
 
             _sut.TypeLookupOverrides = new Dictionary<string, Type>
@@ -119,6 +120,18 @@ namespace Tanzu.Toolkit.VisualStudioExtension.Tests
             GetServiceWasCalled = true;
             GetServiceArgument = serviceType;
             return FakeServiceToReturn ?? "Fake return value (were you expecting a real service?)";
+        }
+    }
+
+    class FakeView : IView
+    {
+        public IViewModel ViewModel => throw new NotImplementedException();
+
+        public Action DisplayView { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public void Show()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/VisualStudioExtension/test/VsViewLocatorServiceTests.cs
+++ b/src/VisualStudioExtension/test/VsViewLocatorServiceTests.cs
@@ -23,13 +23,12 @@ namespace Tanzu.Toolkit.VisualStudioExtension.Tests
 
         private readonly string _fakeViewModelName = "MyCoolViewModel";
         private readonly string _fakeViewName = "IMyCoolView";
-        private Type _fakeViewType;
-        private readonly FakeView _fakeReturnedView = new();
+        private readonly FakeView _fakeView = new();
 
         [TestInitialize]
         public void TestInit()
         {
-            _services = new FakeServiceProvider(_fakeReturnedView);
+            _services = new FakeServiceProvider(_fakeView);
 
             _mockToolWindowService = new Mock<IToolWindowService>();
             _mockLoggingService = new Mock<ILoggingService>();
@@ -38,27 +37,62 @@ namespace Tanzu.Toolkit.VisualStudioExtension.Tests
             _mockLoggingService.SetupGet(m => m.Logger).Returns(_mockLogger.Object);
 
             _sut = new TestVsViewLocatorService(_mockToolWindowService.Object, _mockLoggingService.Object, _services);
-
-            _fakeViewType = GetType(); // some arbitrary type to return
-
-            // pretend that looking up `expectedViewName` returns `fakeViewType`
-            _sut.TypeLookupOverrides = new Dictionary<string, Type>
-            {
-                { _fakeViewName, _fakeViewType }
-            };
         }
 
         [TestMethod]
         [TestCategory("GetViewByViewModelName")]
-        public void GetViewByViewModelName_ReturnsView_OfTypeMatchingProvidedViewModel()
+        public void GetViewByViewModelName_ReturnsView_OfTypeMatchingProvidedViewModel_ForToolWindowTypes()
         {
+            var dummyToolWindowViewType = typeof(IOutputView);
+            Assert.IsTrue(_sut.ViewShownAsToolWindow(dummyToolWindowViewType)); // ensure this type is characterized as a tool window view
+
+            Assert.AreEqual(_sut.GetViewName(_fakeViewModelName), _fakeViewName);
+            _sut.TypeLookupOverrides[_fakeViewName] = dummyToolWindowViewType;
+
+            _mockToolWindowService.Setup(m => m.CreateToolWindowForView(dummyToolWindowViewType, It.IsAny<string>())).Returns(_fakeView);
+
             var result = _sut.GetViewByViewModelName(_fakeViewModelName);
 
-            Assert.AreEqual(_fakeReturnedView, result);
+            Assert.AreEqual(_fakeView, result);
+            _mockToolWindowService.VerifyAll();
+        }
+
+        [TestMethod]
+        [TestCategory("GetViewByViewModelName")]
+        public void GetViewByViewModelName_ReturnsView_OfTypeMatchingProvidedViewModel_ForModalTypes()
+        {
+            var dummyToolWindowViewType = typeof(ILoginView);
+            Assert.IsTrue(_sut.ViewShownAsModal(dummyToolWindowViewType)); // ensure this type is characterized as a modal view
+
+            Assert.AreEqual(_sut.GetViewName(_fakeViewModelName), _fakeViewName);
+            _sut.TypeLookupOverrides[_fakeViewName] = dummyToolWindowViewType;
+
+            var result = _sut.GetViewByViewModelName(_fakeViewModelName);
+
+            Assert.AreEqual(_fakeView, result);
 
             var fakeServiceProvider = _services as FakeServiceProvider;
             Assert.IsTrue(fakeServiceProvider.GetServiceWasCalled);
-            Assert.AreEqual(_fakeViewType, fakeServiceProvider.GetServiceArgument);
+            Assert.AreEqual(dummyToolWindowViewType, fakeServiceProvider.GetServiceArgument);
+        }
+
+        [TestMethod]
+        [TestCategory("GetViewByViewModelName")]
+        public void GetViewByViewModelName_ReturnsNull_AndLogsError_WhenTypeNotModalNorToolWindow()
+        {
+            var dummyToolWindowViewType = GetType(); // some arbitrary type to return
+            _sut.TypeLookupOverrides.Add(_fakeViewName, dummyToolWindowViewType);
+
+            Assert.IsFalse(_sut.ViewShownAsToolWindow(dummyToolWindowViewType));
+            Assert.IsFalse(_sut.ViewShownAsModal(dummyToolWindowViewType));
+
+            var result = _sut.GetViewByViewModelName(_fakeViewModelName);
+
+            Assert.IsNull(result);
+            _mockLogger.Verify(m => m.Error(It.Is<string>(s => s.Contains("given type not classified as either modal or tool window")),
+                                            nameof(VsViewLocatorService),
+                                            nameof(_sut.GetViewByViewModelName),
+                                            _fakeViewModelName), Times.Once);
         }
 
         [TestMethod]
@@ -92,7 +126,7 @@ namespace Tanzu.Toolkit.VisualStudioExtension.Tests
         {
         }
 
-        public Dictionary<string, Type> TypeLookupOverrides { get; set; }
+        public Dictionary<string, Type> TypeLookupOverrides { get; set; } = new Dictionary<string, Type>();
 
         protected override Type LookupViewType(string viewTypeName)
         {

--- a/src/VisualStudioExtension/test/VsViewLocatorServiceTests.cs
+++ b/src/VisualStudioExtension/test/VsViewLocatorServiceTests.cs
@@ -128,10 +128,5 @@ namespace Tanzu.Toolkit.VisualStudioExtension.Tests
         public IViewModel ViewModel => throw new NotImplementedException();
 
         public Action DisplayView { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
-        public void Show()
-        {
-            throw new NotImplementedException();
-        }
     }
 }


### PR DESCRIPTION
fixes #335 
fixes #337 
Ensures that any "Unrecognized service provided" warnings that may arise when importing a default manifest occur *after* the window is shown, not before 