### PR TITLE
Allow cancellation of remote debugging

### DIFF
--- a/src/Services/src/Threading/IThreadingService.cs
+++ b/src/Services/src/Threading/IThreadingService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Tanzu.Toolkit.Services.Threading
@@ -13,6 +14,7 @@ namespace Tanzu.Toolkit.Services.Threading
         Task ExecuteInUIThreadAsync(Action method);
         Task RemoveItemFromCollectionOnUiThreadAsync<T>(ObservableCollection<T> list, T item);
         Task StartBackgroundTask(Func<Task> method);
+        Task StartBackgroundTask(Func<Task> method, CancellationToken cancellationToken);
         void StartRecurrentUiTaskInBackground(Action<object> pollingMethod, object methodParam, int intervalInSeconds);
     }
 }

--- a/src/Services/src/Threading/ThreadingService.cs
+++ b/src/Services/src/Threading/ThreadingService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Tanzu.Toolkit.Services.Threading
@@ -24,6 +25,11 @@ namespace Tanzu.Toolkit.Services.Threading
         public Task StartBackgroundTask(Func<Task> method)
         {
             return method.Invoke();
+        }
+
+        public Task StartBackgroundTask(Func<Task> method, CancellationToken cancellationToken)
+        {
+            return Task.Run(method, cancellationToken);
         }
 
         public void StartRecurrentUiTaskInBackground(Action<object> action, object param, int intervalInSeconds)

--- a/src/ViewModels/src/RemoteDebug/IRemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/IRemoteDebugViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Tanzu.Toolkit.Models;
 
@@ -12,14 +13,15 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
         string LoadingMessage { get; set; }
         Action ViewOpener { get; set; }
         Action ViewCloser { get; set; }
+        Action<object> CancelDebugging { get; set; }
 
         bool CanStartDebuggingApp(object arg = null);
-        void Close(object arg = null);
         Task StartDebuggingAppAsync(object arg = null);
-        void CreateLaunchFileIfNonexistent(string stack);
+        void CreateLaunchFileIfNonexistent(string stack, CancellationToken ct);
         Task PromptAppSelectionAsync(string appName);
         void OpenLoginView(object arg = null);
         void DisplayDeploymentWindow(object arg = null);
         bool CanDisplayDeploymentWindow(object arg = null);
+        bool CanCancelDebugging(object arg = null);
     }
 }

--- a/src/ViewModels/src/RemoteDebug/IRemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/IRemoteDebugViewModel.cs
@@ -21,5 +21,6 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
         void OpenLoginView(object arg = null);
         void DisplayDeploymentWindow(object arg = null);
         bool CanDisplayDeploymentWindow(object arg = null);
+        bool CanCancel(object arg = null);
     }
 }

--- a/src/ViewModels/src/RemoteDebug/IRemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/IRemoteDebugViewModel.cs
@@ -21,6 +21,5 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
         void OpenLoginView(object arg = null);
         void DisplayDeploymentWindow(object arg = null);
         bool CanDisplayDeploymentWindow(object arg = null);
-        bool CanCancel(object arg = null);
     }
 }

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -416,20 +416,17 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
 
             LoadingMessage = $"Checking for debugging agent on {AppToDebug.AppName}...";
             DetailedResult sshResult;
-            bool vsdbExecutableListed;
+            var sshCommand = $"ls {_vsdbgInstallationDirLinux}";
+            var vsdbgName = _vsdbgExecutableNameLinux;
 
             if (stack.Contains("win"))
             {
-                var sshCommand = $"dir {_vsdbgInstallationDirWindows}";
-                sshResult = await _cfCliService.ExecuteSshCommand(AppToDebug.AppName, AppToDebug.ParentSpace.ParentOrg.OrgName, AppToDebug.ParentSpace.SpaceName, sshCommand);
-                vsdbExecutableListed = sshResult.CmdResult.StdOut.Contains(_vsdbgExecutableNameWindows);
+                sshCommand = $"dir {_vsdbgInstallationDirWindows}";
+                vsdbgName = _vsdbgExecutableNameWindows;
             }
-            else
-            {
-                var sshCommand = $"ls {_vsdbgInstallationDirLinux}";
-                sshResult = await _cfCliService.ExecuteSshCommand(AppToDebug.AppName, AppToDebug.ParentSpace.ParentOrg.OrgName, AppToDebug.ParentSpace.SpaceName, sshCommand);
-                vsdbExecutableListed = sshResult.CmdResult.StdOut.Contains(_vsdbgExecutableNameLinux);
-            }
+
+            sshResult = await _cfCliService.ExecuteSshCommand(AppToDebug.AppName, AppToDebug.ParentSpace.ParentOrg.OrgName, AppToDebug.ParentSpace.SpaceName, sshCommand);
+            var vsdbExecutableListed = sshResult.CmdResult.StdOut.Contains(vsdbgName);
 
             return sshResult.Succeeded && vsdbExecutableListed;
         }

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -39,8 +39,6 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
         private bool _debugExistingApp;
         private bool _pushNewAppToDebug;
         private bool _isLoggedIn;
-        private string _option1Text;
-        private string _option2Text;
         private CloudFoundryApp _selectedApp;
         private bool _debugAgentInstalled;
         private bool _launchFileExists;
@@ -78,8 +76,6 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             _outputView = ViewLocatorService.GetViewByViewModelName(nameof(OutputViewModel), $"Remote Debug Output (\"{_projectName}\")") as IView;
             _outputViewModel = _outputView?.ViewModel as IOutputViewModel;
 
-            Option1Text = $"Push new version of \"{expectedAppName}\" to debug";
-            Option2Text = $"Select existing app to debug";
             AppToDebug = null;
             LoadingMessage = null;
 
@@ -183,26 +179,6 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             {
                 _dialogMessage = value;
                 RaisePropertyChangedEvent("DialogMessage");
-            }
-        }
-
-        public string Option1Text
-        {
-            get => _option1Text;
-            set
-            {
-                _option1Text = value;
-                RaisePropertyChangedEvent("Option1Text");
-            }
-        }
-
-        public string Option2Text
-        {
-            get => _option2Text;
-            set
-            {
-                _option2Text = value;
-                RaisePropertyChangedEvent("Option2Text");
             }
         }
 

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -260,10 +260,6 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             {
                 Logger.Error("Unexpected exception caught while attempting to remote debug {AppName}: {RemoteDebugException}", AppToDebug.AppName ?? _projectName, ex);
             }
-            finally
-            {
-                _tokenSource.Dispose();
-            }
         }
 
         public void CreateLaunchFileIfNonexistent(string stack, CancellationToken ct)
@@ -346,6 +342,7 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
 
         private void Close()
         {
+            _tokenSource?.Dispose();
             ThreadingService.ExecuteInUIThread(() => ViewCloser?.Invoke());
         }
 

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -487,6 +487,11 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
         {
             return IsLoggedIn && string.IsNullOrWhiteSpace(LoadingMessage);
         }
+
+        public bool CanCancel(object arg = null)
+        {
+            return string.IsNullOrWhiteSpace(LoadingMessage);
+        }
     }
 
     public class RemoteDebugLaunchConfig

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -260,27 +260,6 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             FileService.DeleteFile(_expectedPathToLaunchFile);
         }
 
-        private async Task<bool> CheckForVsdbg(string stack)
-        {
-            DetailedResult sshResult;
-            bool vsdbExecutableListed;
-
-            if (stack.Contains("win"))
-            {
-                var sshCommand = $"dir {_vsdbgInstallationDirWindows}";
-                sshResult = await _cfCliService.ExecuteSshCommand(AppToDebug.AppName, AppToDebug.ParentSpace.ParentOrg.OrgName, AppToDebug.ParentSpace.SpaceName, sshCommand);
-                vsdbExecutableListed = sshResult.CmdResult.StdOut.Contains(_vsdbgExecutableNameWindows);
-            }
-            else
-            {
-                var sshCommand = $"ls {_vsdbgInstallationDirLinux}";
-                sshResult = await _cfCliService.ExecuteSshCommand(AppToDebug.AppName, AppToDebug.ParentSpace.ParentOrg.OrgName, AppToDebug.ParentSpace.SpaceName, sshCommand);
-                vsdbExecutableListed = sshResult.CmdResult.StdOut.Contains(_vsdbgExecutableNameLinux);
-            }
-
-            return sshResult.Succeeded && vsdbExecutableListed;
-        }
-
         public void CreateLaunchFileIfNonexistent(string stack)
         {
             _launchFileExists = false;
@@ -377,6 +356,27 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
                 vm.OnClose += () => Close();
                 view.DisplayView();
             }
+        }
+
+        private async Task<bool> CheckForVsdbg(string stack)
+        {
+            DetailedResult sshResult;
+            bool vsdbExecutableListed;
+
+            if (stack.Contains("win"))
+            {
+                var sshCommand = $"dir {_vsdbgInstallationDirWindows}";
+                sshResult = await _cfCliService.ExecuteSshCommand(AppToDebug.AppName, AppToDebug.ParentSpace.ParentOrg.OrgName, AppToDebug.ParentSpace.SpaceName, sshCommand);
+                vsdbExecutableListed = sshResult.CmdResult.StdOut.Contains(_vsdbgExecutableNameWindows);
+            }
+            else
+            {
+                var sshCommand = $"ls {_vsdbgInstallationDirLinux}";
+                sshResult = await _cfCliService.ExecuteSshCommand(AppToDebug.AppName, AppToDebug.ParentSpace.ParentOrg.OrgName, AppToDebug.ParentSpace.SpaceName, sshCommand);
+                vsdbExecutableListed = sshResult.CmdResult.StdOut.Contains(_vsdbgExecutableNameLinux);
+            }
+
+            return sshResult.Succeeded && vsdbExecutableListed;
         }
 
         private async Task PopulateAccessibleAppsAsync()

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -379,6 +379,9 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
                 if (!_debugAgentInstalled)
                 {
                     Logger.Error("Failed to install or start debugging agent for app '{AppName}': {DebugFailureMsg}", AppToDebug.AppName, installationResult.Explanation);
+                    ErrorService.DisplayErrorDialog("Unable to install or start debugging agent", installationResult.Explanation);
+                    Close();
+                    return;
                 }
             }
 

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -508,8 +508,6 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
         {
             if (ct.IsCancellationRequested)
             {
-                Close();
-                ResetState();
                 ct.ThrowIfCancellationRequested();
             }
         }

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -386,9 +386,9 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
                 return;
             }
 
+            CanCancel = false;
             LoadingMessage = "Attaching to debugging agent...";
             StopDebuggingAndCloseIfCancelled(ct); // final check before starting debug connection
-            CanCancel = false;
 
             _initiateDebugCallback?.Invoke(AppToDebug.ParentSpace.ParentOrg.OrgName, AppToDebug.ParentSpace.SpaceName);
             Close();

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -487,11 +487,6 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
         {
             return IsLoggedIn && string.IsNullOrWhiteSpace(LoadingMessage);
         }
-
-        public bool CanCancel(object arg = null)
-        {
-            return string.IsNullOrWhiteSpace(LoadingMessage);
-        }
     }
 
     public class RemoteDebugLaunchConfig

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -15,11 +16,13 @@ using Tanzu.Toolkit.Services.DotnetCli;
 using Tanzu.Toolkit.Services.File;
 using Tanzu.Toolkit.Services.Project;
 
+[assembly: InternalsVisibleTo("Tanzu.Toolkit.ViewModels.Tests")]
+
 namespace Tanzu.Toolkit.ViewModels.RemoteDebug
 {
     public class RemoteDebugViewModel : AbstractViewModel, IRemoteDebugViewModel
     {
-        private readonly ITasExplorerViewModel _tasExplorer;
+        internal ITasExplorerViewModel _tasExplorer;
         private ICloudFoundryService _cfClient;
         private readonly ICfCliService _cfCliService;
         private readonly IDotnetCliService _dotnetCliService;

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -346,7 +346,7 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
 
         private void Close()
         {
-            ViewCloser?.Invoke();
+            ThreadingService.ExecuteInUIThread(() => ViewCloser?.Invoke());
         }
 
         public void DisplayDeploymentWindow(object arg = null)

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -202,7 +202,7 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
 
         public Action<object> CancelDebugging { get; set; }
 
-        private bool CanCancel { get; set; }
+        internal bool CanCancel { get; set; }
 
         // Methods //
 
@@ -253,7 +253,7 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
 
             try
             {
-                await RemoteDebugAppAsync(cancellationToken);
+                await ThreadingService.StartBackgroundTask(() => RemoteDebugAppAsync(cancellationToken), cancellationToken);
             }
             catch (OperationCanceledException ex)
             {

--- a/src/ViewModels/test/RemoteDebugViewModelTests.cs
+++ b/src/ViewModels/test/RemoteDebugViewModelTests.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Tanzu.Toolkit.ViewModels.RemoteDebug;
+
+namespace Tanzu.Toolkit.ViewModels.Tests
+{
+    [TestClass]
+    public class RemoteDebugViewModelTests : ViewModelTestSupport
+    {
+        private const string _fakeTargetFrameworkMoniker = "some fake tfm";
+        private const string _fakePathToLaunchFile = "fake\\path\\to\\launch\\file";
+        private RemoteDebugViewModel _sut;
+        private Action<string, string> _fakeDebugCallback;
+
+        [TestInitialize]
+        public void TestInit()
+        {
+            var fakeTasConnection = new FakeCfInstanceViewModel(_fakeCfInstance, Services);
+
+            _sut = new RemoteDebugViewModel(_fakeAppName, _fakeProjectPath, _fakeTargetFrameworkMoniker, _fakePathToLaunchFile, _fakeDebugCallback, Services);
+            MockTasExplorerViewModel.SetupGet(m => m.TasConnection).Returns(fakeTasConnection);
+        }
+
+        [TestCleanup]
+        public void TestCleanup() { }
+
+        [TestMethod]
+        [TestCategory("ctor")]
+        public void Constructor_SetsAppToDebugToNull()
+        {
+            Assert.IsNull(_sut.AppToDebug);
+        }
+
+        [TestMethod]
+        [TestCategory("ctor")]
+        public void Constructor_SetsLoadingMessageToNull()
+        {
+            Assert.IsNull(_sut.LoadingMessage);
+        }
+
+        [TestMethod]
+        [TestCategory("ctor")]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void Constructor_SetsIsLoggedIn(bool mockingLoggedOut)
+        {
+            var expectedValueForIsLoggedIn = !mockingLoggedOut;
+            if (mockingLoggedOut)
+            {
+                MockTasExplorerViewModel.SetupGet(m => m.TasConnection).Returns((CfInstanceViewModel)null);
+            }
+            _sut = new RemoteDebugViewModel(_fakeAppName, _fakeProjectPath, _fakeTargetFrameworkMoniker, _fakePathToLaunchFile, _fakeDebugCallback, Services);
+            Assert.AreEqual(expectedValueForIsLoggedIn, _sut.IsLoggedIn);
+        }
+
+        [TestMethod]
+        [TestCategory("ctor")]
+        public void Constructor_SetsWaitingOnAppConfirmationToFalse()
+        {
+            Assert.IsFalse(_sut.WaitingOnAppConfirmation);
+        }
+
+        [TestMethod]
+        [TestCategory("ctor")]
+        public void Constructor_SetsCanCancelToTrue()
+        {
+            Assert.IsTrue(_sut.CanCancel);
+        }
+
+        [TestMethod]
+        [TestCategory("ctor")]
+        public void Constructor_SetsCancelDebuggingAction()
+        {
+            Assert.IsNotNull(_sut.CancelDebugging);
+        }
+    }
+}

--- a/src/ViewModels/test/RemoteDebugViewModelTests.cs
+++ b/src/ViewModels/test/RemoteDebugViewModelTests.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Tanzu.Toolkit.Models;
+using Tanzu.Toolkit.Services;
 using Tanzu.Toolkit.ViewModels.RemoteDebug;
 
 namespace Tanzu.Toolkit.ViewModels.Tests
@@ -69,6 +71,16 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         [TestCategory("ctor")]
         public void Constructor_PromptsAppSelection_WhenIsLoggedIn()
         {
+            var fakeOrgsResponse = new DetailedResult<List<CloudFoundryOrganization>>
+            {
+                Succeeded = true,
+                Content = _emptyListOfOrgs,
+            };
+
+            MockCloudFoundryService.Setup(m => m.GetOrgsForCfInstanceAsync(
+                It.IsAny<CloudFoundryInstance>(), It.IsAny<bool>(), It.IsAny<int>()))
+                .ReturnsAsync(fakeOrgsResponse);
+
             MockLoggedIn();
 
             Assert.IsTrue(_sut.IsLoggedIn);

--- a/src/ViewModels/test/RemoteDebugViewModelTests.cs
+++ b/src/ViewModels/test/RemoteDebugViewModelTests.cs
@@ -1,5 +1,9 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Tanzu.Toolkit.Models;
 using Tanzu.Toolkit.ViewModels.RemoteDebug;
 
 namespace Tanzu.Toolkit.ViewModels.Tests
@@ -16,9 +20,10 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         public void TestInit()
         {
             var fakeTasConnection = new FakeCfInstanceViewModel(_fakeCfInstance, Services);
+            MockTasExplorerViewModel.SetupGet(m => m.TasConnection).Returns(fakeTasConnection);
+            MockThreadingService.Setup(m => m.StartBackgroundTask(It.IsAny<Func<Task>>(), It.IsAny<CancellationToken>())).Verifiable();
 
             _sut = new RemoteDebugViewModel(_fakeAppName, _fakeProjectPath, _fakeTargetFrameworkMoniker, _fakePathToLaunchFile, _fakeDebugCallback, Services);
-            MockTasExplorerViewModel.SetupGet(m => m.TasConnection).Returns(fakeTasConnection);
         }
 
         [TestCleanup]
@@ -55,13 +60,6 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
         [TestMethod]
         [TestCategory("ctor")]
-        public void Constructor_SetsWaitingOnAppConfirmationToFalse()
-        {
-            Assert.IsFalse(_sut.WaitingOnAppConfirmation);
-        }
-
-        [TestMethod]
-        [TestCategory("ctor")]
         public void Constructor_SetsCanCancelToTrue()
         {
             Assert.IsTrue(_sut.CanCancel);
@@ -72,6 +70,32 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         public void Constructor_SetsCancelDebuggingAction()
         {
             Assert.IsNotNull(_sut.CancelDebugging);
+        }
+
+        [TestMethod]
+        [TestCategory("ctor")]
+        public void Constructor_PromptsAppSelection_WhenIsLoggedIn()
+        {
+            Assert.IsTrue(_sut.IsLoggedIn);
+            Assert.AreEqual("Select app to debug:", _sut.DialogMessage);
+            Assert.IsNull(_sut.LoadingMessage);
+        }
+
+        [TestMethod]
+        [TestCategory("ctor")]
+        public void Constructor_DoesNotPromptAppSelection_WhenNotLoggedIn()
+        {
+            MockTasExplorerViewModel.SetupGet(m => m.TasConnection).Returns((CfInstanceViewModel)null);
+            MockCloudFoundryService.Invocations.Clear(); // reset any invocations from test init construction
+
+            _sut = new RemoteDebugViewModel(_fakeAppName, _fakeProjectPath, _fakeTargetFrameworkMoniker, _fakePathToLaunchFile, _fakeDebugCallback, Services);
+
+            Assert.IsNull(_sut._tasExplorer.TasConnection);
+
+            MockCloudFoundryService.Verify(m => m.GetOrgsForCfInstanceAsync(It.IsAny<CloudFoundryInstance>(), It.IsAny<bool>(), It.IsAny<int>()), Times.Never);
+            
+            Assert.IsNull(_sut.LoadingMessage);
+            Assert.IsNull(_sut.DialogMessage);
         }
     }
 }

--- a/src/ViewModels/test/RemoteDebugViewModelTests.cs
+++ b/src/ViewModels/test/RemoteDebugViewModelTests.cs
@@ -24,9 +24,6 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             _sut = new RemoteDebugViewModel(_fakeAppName, _fakeProjectPath, _fakeTargetFrameworkMoniker, _fakePathToLaunchFile, null, Services);
         }
 
-        [TestCleanup]
-        public void TestCleanup() { }
-
         [TestMethod]
         [TestCategory("ctor")]
         public void Constructor_SetsAppToDebugToNull()

--- a/src/ViewModels/test/ViewModelTestSupport.cs
+++ b/src/ViewModels/test/ViewModelTestSupport.cs
@@ -8,9 +8,11 @@ using System.IO;
 using System.Threading.Tasks;
 using Tanzu.Toolkit.Models;
 using Tanzu.Toolkit.Services;
+using Tanzu.Toolkit.Services.CfCli;
 using Tanzu.Toolkit.Services.CloudFoundry;
 using Tanzu.Toolkit.Services.CommandProcess;
 using Tanzu.Toolkit.Services.DataPersistence;
+using Tanzu.Toolkit.Services.DebugAgentProvider;
 using Tanzu.Toolkit.Services.Dialog;
 using Tanzu.Toolkit.Services.DotnetCli;
 using Tanzu.Toolkit.Services.ErrorDialog;
@@ -43,6 +45,8 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         protected Mock<ILoginViewModel> MockLoginViewModel { get; set; }
         protected Mock<IAppDeletionConfirmationViewModel> MockAppDeletionConfirmationViewModel { get; set; }
         protected Mock<IProjectService> MockProjectService { get; set; }
+        protected Mock<ICfCliService> MockCfCliService { get; set; }
+        protected Mock<IDebugAgentProvider> MockDebugAgentProvider { get; set; }
 
         protected const string _fakeCfName = "fake cf name";
         protected const string _fakeCfApiAddress = "http://fake.api.address";
@@ -492,6 +496,8 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             MockLoginViewModel = new Mock<ILoginViewModel>();
             MockAppDeletionConfirmationViewModel = new Mock<IAppDeletionConfirmationViewModel>();
             MockProjectService = new Mock<IProjectService>();
+            MockCfCliService = new Mock<ICfCliService>();
+            MockDebugAgentProvider = new Mock<IDebugAgentProvider>();
 
             MockLogger = new Mock<ILogger>();
             MockLoggingService.SetupGet(m => m.Logger).Returns(MockLogger.Object);
@@ -511,6 +517,8 @@ namespace Tanzu.Toolkit.ViewModels.Tests
             services.AddSingleton(MockLoginViewModel.Object);
             services.AddSingleton(MockAppDeletionConfirmationViewModel.Object);
             services.AddSingleton(MockProjectService.Object);
+            services.AddSingleton(MockCfCliService.Object);
+            services.AddSingleton(MockDebugAgentProvider.Object);
 
             Services = services.BuildServiceProvider();
         }

--- a/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml.cs
@@ -32,7 +32,7 @@ namespace Tanzu.Toolkit.VisualStudio
 
             themeService.SetTheme(this);
             DataContext = viewModel;
-            CancelCommand = new DelegatingCommand(viewModel.Close, viewModel.CanCancel);
+            CancelCommand = new DelegatingCommand(viewModel.Close, alwaysTrue);
             OpenLoginViewCommand = new DelegatingCommand(viewModel.OpenLoginView, alwaysTrue);
             ResolveMissingAppCommand = new AsyncDelegatingCommand(viewModel.StartDebuggingAppAsync, viewModel.CanStartDebuggingApp);
             ShowDeploymentWindowCommand = new DelegatingCommand(viewModel.DisplayDeploymentWindow, viewModel.CanDisplayDeploymentWindow);

--- a/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml.cs
@@ -32,7 +32,7 @@ namespace Tanzu.Toolkit.VisualStudio
 
             themeService.SetTheme(this);
             DataContext = viewModel;
-            CancelCommand = new DelegatingCommand(viewModel.Close, alwaysTrue);
+            CancelCommand = new DelegatingCommand(viewModel.CancelDebugging, viewModel.CanCancelDebugging);
             OpenLoginViewCommand = new DelegatingCommand(viewModel.OpenLoginView, alwaysTrue);
             ResolveMissingAppCommand = new AsyncDelegatingCommand(viewModel.StartDebuggingAppAsync, viewModel.CanStartDebuggingApp);
             ShowDeploymentWindowCommand = new DelegatingCommand(viewModel.DisplayDeploymentWindow, viewModel.CanDisplayDeploymentWindow);

--- a/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml.cs
@@ -32,7 +32,7 @@ namespace Tanzu.Toolkit.VisualStudio
 
             themeService.SetTheme(this);
             DataContext = viewModel;
-            CancelCommand = new DelegatingCommand(viewModel.Close, alwaysTrue);
+            CancelCommand = new DelegatingCommand(viewModel.Close, viewModel.CanCancel);
             OpenLoginViewCommand = new DelegatingCommand(viewModel.OpenLoginView, alwaysTrue);
             ResolveMissingAppCommand = new AsyncDelegatingCommand(viewModel.StartDebuggingAppAsync, viewModel.CanStartDebuggingApp);
             ShowDeploymentWindowCommand = new DelegatingCommand(viewModel.DisplayDeploymentWindow, viewModel.CanDisplayDeploymentWindow);


### PR DESCRIPTION
- Add cancellation token to each task in the chain for initiating remote debugging
- Tasks stop & window closes when token cancelled
- "Cancel" button on remote debug window works to cancel the process up until the request is sent to attach to the remote process
- Misc code cleanup in `RemoteDebugViewModel`
- Add tests for `RemoteDebugViewModel` (these are not comprehensive! Many more tests needed for this class)