### PR TITLE
Open deployment output window after deploying app (bug fix)

### DIFF
--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -569,12 +569,8 @@ namespace Tanzu.Toolkit.ViewModels
                 DeploymentInProgress = true;
                 var _ = ThreadingService.StartBackgroundTask(StartDeployment);
                 DialogService.CloseDialog(dialogWindow, true);
+                OnClosed();
             }
-        }
-
-        public void DisplayDeploymentOutput()
-        {
-            _outputView.DisplayView();
         }
 
         public bool CanOpenLoginView(object arg)
@@ -1125,6 +1121,11 @@ namespace Tanzu.Toolkit.ViewModels
             var path = appManifest.Applications[0].Path;
 
             DeploymentDirectoryPath = string.IsNullOrWhiteSpace(path) ? null : path;
+        }
+
+        private void DisplayDeploymentOutput()
+        {
+            _outputView.DisplayView();
         }
     }
 

--- a/src/ViewModels/src/DeploymentDialog/IDeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/IDeploymentDialogViewModel.cs
@@ -35,6 +35,5 @@ namespace Tanzu.Toolkit.ViewModels
         void ClearSelectedServices(object arg = null);
         void ClearSelectedManifest(object arg = null);
         void ClearSelectedDeploymentDirectory(object arg = null);
-        void DisplayDeploymentOutput();
     }
 }

--- a/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
@@ -54,12 +54,6 @@ namespace Tanzu.Toolkit.VisualStudio.Views
             base.OnContentRendered(e);
         }
 
-        protected override void OnClosed(EventArgs e)
-        {
-            _viewModel.OnClosed();
-            base.OnClosed(e);
-        }
-
         private void CfOrgOptions_ComboBox_DropDownClosed(object sender, System.EventArgs e)
         {
             var _ = _viewModel.UpdateCfSpaceOptions();
@@ -97,6 +91,7 @@ namespace Tanzu.Toolkit.VisualStudio.Views
         private void Close(object sender, RoutedEventArgs e)
         {
             Close();
+            _viewModel.OnClosed();
         }
 
         private void BuildpackItemSelected(object sender, RoutedEventArgs e)


### PR DESCRIPTION
- Invoke `DisplayDeploymentOutput()` explicitly after closing dialog in `DeploymentDialogViewModel.DeployApp`
  - this method was previously supposed to be called by the `OnClosed` override in `DeploymentDialogView.xaml.cs`, but it turns out that `OnClosed` wasn't being triggered by the window closing (even though its counterpart `OnRendered` is triggered as expected... 🤔)
- make `DisplayDeploymentOutput()` private (view model should be the only one calling it)
- fixes #363 