### PR TITLE
Print "recent" app logs before streaming logs

### DIFF
--- a/src/ViewModels/src/Output/OutputViewModel.cs
+++ b/src/ViewModels/src/Output/OutputViewModel.cs
@@ -56,7 +56,7 @@ namespace Tanzu.Toolkit.ViewModels
 
         public void AppendLine(string newContent)
         {
-            if (!OutputPaused && !newContent.StartsWith("Retrieving logs for app"))
+            if (!OutputPaused)
             {
                 var newLine = $"{newContent}\n";
                 if (!string.IsNullOrWhiteSpace(newLine))


### PR DESCRIPTION
- remove conditional exclusion for printing lines of log output that
  begin with "Retrieving logs for app"
- not sure why this exclusion was added in the first place... maybe to
  prevent that particular header "Retrieving logs for app" from being
  repeated (it is very similar to the header printed by this vsix:
  "Fetching recent app logs for...")
- fixes #365 