### PR TITLE
Fix bug occasionally preventing Login view from opening

### DIFF
--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -137,7 +137,7 @@ namespace Tanzu.Toolkit.ViewModels
 
             OnRendered = () => SetManifestIfDefaultExists();
 
-            OnClosed = () =>
+            OnClose = () =>
             {
                 DialogService.CloseDialogByName(nameof(DeploymentDialogViewModel));
                 if (DeploymentInProgress) // don't open tool window if modal was closed via "X" button
@@ -554,7 +554,7 @@ namespace Tanzu.Toolkit.ViewModels
             }
         }
 
-        public Action OnClosed { get; set; }
+        public Action OnClose { get; set; }
 
         public Action OnRendered { get; set; }
 
@@ -570,7 +570,7 @@ namespace Tanzu.Toolkit.ViewModels
                 DeploymentInProgress = true;
                 var _ = ThreadingService.StartBackgroundTask(StartDeployment);
                 DialogService.CloseDialog(dialogWindow, true);
-                OnClosed();
+                OnClose();
             }
         }
 

--- a/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -139,6 +139,7 @@ namespace Tanzu.Toolkit.ViewModels
 
             OnClosed = () =>
             {
+                DialogService.CloseDialogByName(nameof(DeploymentDialogViewModel));
                 if (DeploymentInProgress) // don't open tool window if modal was closed via "X" button
                 {
                     DisplayDeploymentOutput();

--- a/src/ViewModels/src/DeploymentDialog/IDeploymentDialogViewModel.cs
+++ b/src/ViewModels/src/DeploymentDialog/IDeploymentDialogViewModel.cs
@@ -16,7 +16,7 @@ namespace Tanzu.Toolkit.ViewModels
         bool ConfigureForRemoteDebugging { get; set; }
         bool IsLoggedIn { get; set; }
         Action OnRendered { get; set; }
-        Action OnClosed { get; set; }
+        Action OnClose { get; set; }
 
         bool CanDeployApp(object arg);
         bool CanToggleAdvancedOptions(object arg);

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -429,7 +429,7 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             if (view.ViewModel is IDeploymentDialogViewModel vm)
             {
                 vm.ConfigureForRemoteDebugging = true;
-                vm.OnClosed += () => Close();
+                vm.OnClose += () => Close();
                 view.DisplayView();
             }
         }

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -229,24 +229,24 @@ namespace Tanzu.Toolkit.ViewModels.Tests
 
         [TestMethod]
         [TestCategory("ctor")]
-        [TestCategory("OnClosed")]
-        public void Constructor_SetsOnClosedAction_ToCloseDeploymentDialog()
+        [TestCategory("OnClose")]
+        public void Constructor_SetsOnCloseAction_ToCloseDeploymentDialog()
         {
-            _sut.OnClosed();
+            _sut.OnClose();
 
             MockDialogService.Verify(m => m.CloseDialogByName(nameof(DeploymentDialogViewModel), It.IsAny<object>()), Times.Once);
         }
 
         [TestMethod]
         [TestCategory("ctor")]
-        [TestCategory("OnClosed")]
-        public void Constructor_SetsOnClosedAction_ToDisplayDeploymentOutputIfDeploymentInProgress()
+        [TestCategory("OnClose")]
+        public void Constructor_SetsOnCloseAction_ToDisplayDeploymentOutputIfDeploymentInProgress()
         {
             Assert.AreEqual(_fakeOutputView, _sut._outputView);
             Assert.IsFalse(_fakeOutputView.ShowMethodWasCalled);
             _sut.DeploymentInProgress = true; // fake so action will try to display output view
 
-            _sut.OnClosed();
+            _sut.OnClose();
 
             Assert.IsTrue(_fakeOutputView.ShowMethodWasCalled);
         }

--- a/src/ViewModels/test/DeploymentDialogViewModelTests.cs
+++ b/src/ViewModels/test/DeploymentDialogViewModelTests.cs
@@ -230,6 +230,16 @@ namespace Tanzu.Toolkit.ViewModels.Tests
         [TestMethod]
         [TestCategory("ctor")]
         [TestCategory("OnClosed")]
+        public void Constructor_SetsOnClosedAction_ToCloseDeploymentDialog()
+        {
+            _sut.OnClosed();
+
+            MockDialogService.Verify(m => m.CloseDialogByName(nameof(DeploymentDialogViewModel), It.IsAny<object>()), Times.Once);
+        }
+
+        [TestMethod]
+        [TestCategory("ctor")]
+        [TestCategory("OnClosed")]
         public void Constructor_SetsOnClosedAction_ToDisplayDeploymentOutputIfDeploymentInProgress()
         {
             Assert.AreEqual(_fakeOutputView, _sut._outputView);

--- a/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
@@ -90,7 +90,7 @@ namespace Tanzu.Toolkit.VisualStudio.Views
 
         private void Close(object sender, RoutedEventArgs e)
         {
-            Close();
+            Hide(); // important to hide instead of closing (which has a side effect of permanently closing LoginView)
             _viewModel.OnClosed();
         }
 

--- a/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/DeploymentDialogView.xaml.cs
@@ -91,7 +91,7 @@ namespace Tanzu.Toolkit.VisualStudio.Views
         private void Close(object sender, RoutedEventArgs e)
         {
             Hide(); // important to hide instead of closing (which has a side effect of permanently closing LoginView)
-            _viewModel.OnClosed();
+            _viewModel.OnClose();
         }
 
         private void BuildpackItemSelected(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Previously, closing the deployment dialog had a side effect of also closing the login window (if it was opened from the deployment dialog). This prevented the login view from ever being able to be displayed again without raising an error ("Cannot call show after window has closed").

![login-view-error-#370.gif](https://images.zenhubusercontent.com/5f6e427c72f8abbfafb30775/8c8407e7-08d8-4fc7-a663-c6cf4a69520a)

Now the deployment dialog is closed with a different method that allows the login view to be reopened (`.Hide()` in WPF, followed by `DialogService.CloseDialogByName` seems to close just the deployment dialog without closing the login window)