### PR TITLE
Fix bug in remote debugger that *always* chose app matching project name

### DIFF
--- a/src/ViewModels/src/RemoteDebug/IRemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/IRemoteDebugViewModel.cs
@@ -13,9 +13,9 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
         Action ViewOpener { get; set; }
         Action ViewCloser { get; set; }
 
-        bool CanResolveMissingApp(object arg = null);
+        bool CanStartDebuggingApp(object arg = null);
         void Close(object arg = null);
-        void ConfirmAppToDebug(object arg = null);
+        Task StartDebuggingAppAsync(object arg = null);
         void CreateLaunchFileIfNonexistent(string stack);
         Task BeginRemoteDebuggingAsync(string appName);
         void OpenLoginView(object arg = null);

--- a/src/ViewModels/src/RemoteDebug/IRemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/IRemoteDebugViewModel.cs
@@ -18,7 +18,6 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
         void ConfirmAppToDebug(object arg = null);
         void CreateLaunchFileIfNonexistent(string stack);
         Task BeginRemoteDebuggingAsync(string appName);
-        Task EstablishAppToDebugAsync(string expectedAppName);
         void OpenLoginView(object arg = null);
         void DisplayDeploymentWindow(object arg = null);
         bool CanDisplayDeploymentWindow(object arg = null);

--- a/src/ViewModels/src/RemoteDebug/IRemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/IRemoteDebugViewModel.cs
@@ -17,7 +17,7 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
         void Close(object arg = null);
         Task StartDebuggingAppAsync(object arg = null);
         void CreateLaunchFileIfNonexistent(string stack);
-        Task BeginRemoteDebuggingAsync(string appName);
+        Task PromptAppSelectionAsync(string appName);
         void OpenLoginView(object arg = null);
         void DisplayDeploymentWindow(object arg = null);
         bool CanDisplayDeploymentWindow(object arg = null);

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -280,7 +280,7 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             FileService.DeleteFile(_expectedPathToLaunchFile);
         }
 
-        public void ConfirmAppToDebug(object arg = null)
+        public async Task StartDebuggingAppAsync(object arg = null)
         {
             AppToDebug = SelectedApp;
             var _ = BeginRemoteDebuggingAsync(AppToDebug.AppName); // start debug process over from beginning
@@ -486,7 +486,7 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
 
         // Predicates //
 
-        public bool CanResolveMissingApp(object arg = null)
+        public bool CanStartDebuggingApp(object arg = null)
         {
             return SelectedApp != null;
         }

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -240,6 +240,9 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
         {
             LoadingMessage = "Fetching apps...";
             await PopulateAccessibleAppsAsync();
+
+            LoadingMessage = null;
+            DialogMessage = "Select app to debug:";
         }
 
         public async Task StartDebuggingAppAsync(object arg = null)

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -403,12 +403,6 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             }
         }
 
-        private void PromptAppResolution()
-        {
-            LoadingMessage = null;
-            DialogMessage = "Select app to debug:";
-        }
-
         private async Task PopulateAccessibleAppsAsync()
         {
             try

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -88,7 +88,7 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             {
                 IsLoggedIn = true;
                 _cfClient = _tasExplorer.TasConnection.CfClient;
-                var _ = BeginRemoteDebuggingAsync(expectedAppName);
+                var _ = PromptAppSelectionAsync(expectedAppName);
             }
         }
 
@@ -232,11 +232,11 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
             {
                 IsLoggedIn = true;
                 _cfClient = _tasExplorer.TasConnection.CfClient;
-                var _ = BeginRemoteDebuggingAsync(_projectName);
+                var _ = PromptAppSelectionAsync(_projectName);
             }
         }
 
-        public async Task BeginRemoteDebuggingAsync(string appName)
+        public async Task PromptAppSelectionAsync(string appName)
         {
             LoadingMessage = "Fetching apps...";
             await PopulateAccessibleAppsAsync();

--- a/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
+++ b/src/ViewModels/src/RemoteDebug/RemoteDebugViewModel.cs
@@ -240,44 +240,6 @@ namespace Tanzu.Toolkit.ViewModels.RemoteDebug
         {
             LoadingMessage = "Fetching apps...";
             await PopulateAccessibleAppsAsync();
-
-            PromptAppResolution();
-
-            // sanity check; AppToDebug should always be populated by this step
-            if (AppToDebug == null)
-            {
-                ErrorService.DisplayErrorDialog("Remote Debug Error", "Unable to identify app to debug.\n" +
-                    "This is unexpected; it may help to sign out of TAS & try debugging again after logging back in.\n" +
-                    "If this issue persists, please contact tas-vs-extension@vmware.com");
-                Close();
-                return;
-            }
-            
-            LoadingMessage = $"Checking for debugging agent on {AppToDebug.AppName}...";
-
-            _debugAgentInstalled = await CheckForVsdbg(AppToDebug.Stack);
-            if (!_debugAgentInstalled)
-            {
-                LoadingMessage = $"Installing debugging agent for {AppToDebug.AppName}...";
-                var installationResult = await _vsdbgInstaller.InstallVsdbgForCFAppAsync(AppToDebug);
-                _debugAgentInstalled = await CheckForVsdbg(AppToDebug.Stack);
-                if (!_debugAgentInstalled)
-                {
-                    Logger.Error("Failed to install or start debugging agent for app '{AppName}': {DebugFailureMsg}", AppToDebug.AppName, installationResult.Explanation);
-                }
-            }
-
-            CreateLaunchFileIfNonexistent(AppToDebug.Stack);
-            if (!_launchFileExists)
-            {
-                Close();
-                return;
-            }
-
-            LoadingMessage = "Attaching to debugging agent...";
-            _initiateDebugCallback?.Invoke(AppToDebug.ParentSpace.ParentOrg.OrgName, AppToDebug.ParentSpace.SpaceName);
-            Close();
-            FileService.DeleteFile(_expectedPathToLaunchFile);
         }
 
         public async Task StartDebuggingAppAsync(object arg = null)

--- a/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml.cs
+++ b/src/VisualStudioExtension/src/Views/RemoteDebugView.xaml.cs
@@ -34,7 +34,7 @@ namespace Tanzu.Toolkit.VisualStudio
             DataContext = viewModel;
             CancelCommand = new DelegatingCommand(viewModel.Close, alwaysTrue);
             OpenLoginViewCommand = new DelegatingCommand(viewModel.OpenLoginView, alwaysTrue);
-            ResolveMissingAppCommand = new DelegatingCommand(viewModel.ConfirmAppToDebug, viewModel.CanResolveMissingApp);
+            ResolveMissingAppCommand = new AsyncDelegatingCommand(viewModel.StartDebuggingAppAsync, viewModel.CanStartDebuggingApp);
             ShowDeploymentWindowCommand = new DelegatingCommand(viewModel.DisplayDeploymentWindow, viewModel.CanDisplayDeploymentWindow);
             MouseDown += Window_MouseDown;
             InitializeComponent();


### PR DESCRIPTION
- fixes #356 
- removed the initial step of the debugging process that checked for any apps matching the same name as the targeted .net app
- start debugging session with a prompt to select the app to debug (no automatic smart decisions)
- refactor some methods / messages in RemoteDebugViewModel in an effort to clarify the process (both to users & devs)